### PR TITLE
refactor(nexus-workflow-app): extract db:reset into standalone CLI script

### DIFF
--- a/nexus-workflow-app/package.json
+++ b/nexus-workflow-app/package.json
@@ -6,6 +6,7 @@
   "private": true,
   "scripts": {
     "dev": "tsx watch src/main.ts",
+    "db:reset": "tsx src/db/reset-cli.ts",
     "build": "tsc",
     "start": "node dist/main.js",
     "typecheck": "tsc --noEmit",

--- a/nexus-workflow-app/src/config.ts
+++ b/nexus-workflow-app/src/config.ts
@@ -3,5 +3,4 @@ export const config = {
   databaseUrl: process.env['DATABASE_URL'] ?? 'postgres://localhost/nexus_workflow',
   nodeEnv: process.env['NODE_ENV'] ?? 'development',
   redisUrl: process.env['REDIS_URL'] ?? 'redis://localhost:6379',
-  resetDb: process.env['RESET_DB'] === 'true',
 }

--- a/nexus-workflow-app/src/db/reset-cli.ts
+++ b/nexus-workflow-app/src/db/reset-cli.ts
@@ -1,0 +1,5 @@
+import { config } from '../config.js'
+import { resetDatabase } from './migrate.js'
+
+await resetDatabase(config.databaseUrl)
+console.log('Done.')

--- a/nexus-workflow-app/src/main.ts
+++ b/nexus-workflow-app/src/main.ts
@@ -3,7 +3,7 @@ import { Hono } from 'hono'
 import { InMemoryEventBus } from 'nexus-workflow-core'
 import { config } from './config.js'
 import { PostgresStateStore } from './db/PostgresStateStore.js'
-import { runMigrations, resetDatabase } from './db/migrate.js'
+import { runMigrations } from './db/migrate.js'
 import { createDefinitionsRouter } from './http/definitions.js'
 import { createInstancesRouter } from './http/instances.js'
 import { createTasksRouter } from './http/tasks.js'
@@ -22,6 +22,8 @@ const store = new PostgresStateStore(config.databaseUrl)
 const eventBus = new InMemoryEventBus()
 const eventLog = new PostgresEventLog(config.databaseUrl)
 eventBus.subscribe(event => { void eventLog.append(event) })
+
+await runMigrations(config.databaseUrl)
 
 if (config.redisUrl) {
   const redisPublisher = new RedisStreamPublisher(config.redisUrl)
@@ -47,12 +49,6 @@ app.route('/', createTasksRouter(store, eventBus))
 app.route('/', createAdminRouter(store, eventBus))
 app.route('/', createEventsRouter(store, eventBus))
 app.route('/', createObservabilityRouter(store, eventLog))
-
-if (config.resetDb) {
-  await resetDatabase(config.databaseUrl)
-} else {
-  await runMigrations(config.databaseUrl)
-}
 serve({ fetch: app.fetch, port: config.port }, () => {
   console.log(`nexus-workflow-app listening on port ${config.port}`)
 })


### PR DESCRIPTION
## Summary

- Moves database reset logic out of `main.ts` (previously gated behind a `RESET_DB` env flag) into a dedicated `src/db/reset-cli.ts` script
- `main.ts` now always runs migrations unconditionally on startup — no more env flag needed
- Exposes the reset script as `npm run db:reset` in `package.json`

## Test plan

- [ ] `npm run dev` starts the app and runs migrations automatically
- [ ] `npm run db:reset` resets the database without starting the server
- [ ] `RESET_DB` env var is no longer referenced anywhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)