### PR TITLE
fix(nexus-erp): eliminate hydration mismatch and fix dark-mode calendar theme

### DIFF
--- a/nexus-erp/src/app/(app)/timesheets/TimesheetCalendar.tsx
+++ b/nexus-erp/src/app/(app)/timesheets/TimesheetCalendar.tsx
@@ -9,6 +9,7 @@ import IconButton from '@mui/material/IconButton'
 import CircularProgress from '@mui/material/CircularProgress'
 import Collapse from '@mui/material/Collapse'
 import Tooltip from '@mui/material/Tooltip'
+import { useTheme, alpha } from '@mui/material/styles'
 import ChevronLeftRoundedIcon from '@mui/icons-material/ChevronLeftRounded'
 import ChevronRightRoundedIcon from '@mui/icons-material/ChevronRightRounded'
 import ExpandLessRoundedIcon from '@mui/icons-material/ExpandLessRounded'
@@ -31,49 +32,34 @@ type Timesheet = {
   entries: TimesheetEntry[]
 }
 
-const STATUS_CONFIG: Record<string, { label: string; bgColor: string; borderColor: string; textColor: string }> = {
-  draft: {
-    label: 'Draft',
-    bgColor: '#F9FAFB',
-    borderColor: '#D1D5DB',
-    textColor: '#6B7280',
-  },
-  submitted: {
-    label: 'Submitted',
-    bgColor: '#FFFBEB',
-    borderColor: '#F59E0B',
-    textColor: '#B45309',
-  },
-  pending_manager_review: {
-    label: 'Manager Review',
-    bgColor: '#EFF6FF',
-    borderColor: '#3B82F6',
-    textColor: '#1D4ED8',
-  },
-  pending_hr_review: {
-    label: 'HR Review',
-    bgColor: '#F5F3FF',
-    borderColor: '#8B5CF6',
-    textColor: '#6D28D9',
-  },
-  revision_requested: {
-    label: 'Revision Requested',
-    bgColor: '#FFF7ED',
-    borderColor: '#F97316',
-    textColor: '#C2410C',
-  },
-  approved: {
-    label: 'Approved',
-    bgColor: '#F0FDF4',
-    borderColor: '#22C55E',
-    textColor: '#15803D',
-  },
-  rejected: {
-    label: 'Rejected',
-    bgColor: '#FFF1F2',
-    borderColor: '#F43F5E',
-    textColor: '#BE123C',
-  },
+type StatusCfg = { label: string; bgColor: string; borderColor: string; textColor: string }
+
+function useStatusConfig(): Record<string, StatusCfg> {
+  const theme = useTheme()
+  const { palette } = theme
+  const isDark = palette.mode === 'dark'
+
+  if (!isDark) {
+    return {
+      draft:                  { label: 'Draft',            bgColor: '#F9FAFB',                                    borderColor: '#D1D5DB',                          textColor: '#6B7280' },
+      submitted:              { label: 'Submitted',        bgColor: '#FFFBEB',                                    borderColor: '#F59E0B',                          textColor: '#B45309' },
+      pending_manager_review: { label: 'Manager Review',   bgColor: '#EFF6FF',                                    borderColor: '#3B82F6',                          textColor: '#1D4ED8' },
+      pending_hr_review:      { label: 'HR Review',        bgColor: '#F5F3FF',                                    borderColor: '#8B5CF6',                          textColor: '#6D28D9' },
+      revision_requested:     { label: 'Revision Request', bgColor: '#FFF7ED',                                    borderColor: '#F97316',                          textColor: '#C2410C' },
+      approved:               { label: 'Approved',         bgColor: '#F0FDF4',                                    borderColor: '#22C55E',                          textColor: '#15803D' },
+      rejected:               { label: 'Rejected',         bgColor: '#FFF1F2',                                    borderColor: '#F43F5E',                          textColor: '#BE123C' },
+    }
+  }
+
+  return {
+    draft:                  { label: 'Draft',            bgColor: alpha(palette.grey[500], 0.12),            borderColor: alpha(palette.grey[500], 0.35),     textColor: palette.grey[400] },
+    submitted:              { label: 'Submitted',        bgColor: alpha(palette.warning.main, 0.12),         borderColor: alpha(palette.warning.main, 0.45),  textColor: palette.warning.light },
+    pending_manager_review: { label: 'Manager Review',   bgColor: alpha(palette.info.main, 0.12),            borderColor: alpha(palette.info.main, 0.45),     textColor: palette.info.light },
+    pending_hr_review:      { label: 'HR Review',        bgColor: alpha(palette.secondary.main, 0.12),       borderColor: alpha(palette.secondary.main, 0.45), textColor: palette.secondary.light },
+    revision_requested:     { label: 'Revision Request', bgColor: alpha(palette.warning.dark, 0.15),         borderColor: alpha(palette.warning.dark, 0.5),   textColor: palette.warning.main },
+    approved:               { label: 'Approved',         bgColor: alpha(palette.success.main, 0.12),         borderColor: alpha(palette.success.main, 0.45),  textColor: palette.success.light },
+    rejected:               { label: 'Rejected',         bgColor: alpha(palette.error.main, 0.12),           borderColor: alpha(palette.error.main, 0.45),    textColor: palette.error.light },
+  }
 }
 
 const DAY_LABELS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
@@ -123,6 +109,7 @@ function getCalendarRange(year: number, month: number): { from: string; to: stri
 }
 
 const TimesheetCalendar = () => {
+  const STATUS_CONFIG = useStatusConfig()
   const today = new Date()
   const [viewDate, setViewDate] = useState(() => new Date(today.getFullYear(), today.getMonth(), 1))
   const [timesheets, setTimesheets] = useState<Timesheet[]>([])
@@ -226,7 +213,7 @@ const TimesheetCalendar = () => {
           borderBottom: 'none',
           borderRadius: '8px 8px 0 0',
           overflow: 'hidden',
-          bgcolor: 'grey.50',
+          bgcolor: 'action.hover',
         }}
       >
         {DAY_LABELS.map((day, i) => (
@@ -298,7 +285,7 @@ const TimesheetCalendar = () => {
                         pt: 1,
                         pb: 0.5,
                         minHeight: 48,
-                        bgcolor: isWeekend ? 'grey.50' : 'background.paper',
+                        bgcolor: isWeekend ? 'action.hover' : 'background.paper',
                         borderRight: offset < 6 ? '1px solid' : 'none',
                         borderColor: 'divider',
                         opacity: isCurrentMonth ? 1 : 0.45,
@@ -389,7 +376,7 @@ const TimesheetCalendar = () => {
                   sx={{
                     borderLeft: '1px solid',
                     borderColor: 'divider',
-                    bgcolor: 'grey.50',
+                    bgcolor: 'action.hover',
                     display: 'flex',
                     alignItems: 'center',
                     justifyContent: 'center',
@@ -446,7 +433,7 @@ const TimesheetCalendar = () => {
                         '&:hover': {
                           borderColor: 'primary.main',
                           color: 'primary.main',
-                          bgcolor: 'primary.50',
+                          bgcolor: (theme) => alpha(theme.palette.primary.main, 0.08),
                         },
                       }}
                     >

--- a/nexus-erp/src/app/layout.tsx
+++ b/nexus-erp/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next'
 import './globals.css'
 import 'bpmn-js/dist/assets/diagram-js.css'
 import 'bpmn-js/dist/assets/bpmn-js.css'
+import { cookies } from 'next/headers'
 import { auth } from '@/auth'
 import ThemeRegistry from '@/components/ThemeRegistry'
 
@@ -11,19 +12,12 @@ export const metadata: Metadata = {
 }
 
 const RootLayout = async ({ children }: { children: React.ReactNode }) => {
-  const session = await auth()
-  const initialTheme = session?.user?.theme ?? 'system'
+  const [session, cookieStore] = await Promise.all([auth(), cookies()])
+  const initialTheme =
+    cookieStore.get('nexus-theme')?.value ?? session?.user?.theme ?? 'system'
 
   return (
-    <html lang="en">
-      <head>
-        {/* Blocking script: apply theme from localStorage before React hydration to prevent FOUT */}
-        <script
-          dangerouslySetInnerHTML={{
-            __html: `(function(){try{var t=localStorage.getItem('nexus-theme');if(t)document.documentElement.setAttribute('data-theme',t);}catch(e){}})()`,
-          }}
-        />
-      </head>
+    <html lang="en" data-theme={initialTheme}>
       <body>
         <ThemeRegistry initialTheme={initialTheme}>{children}</ThemeRegistry>
       </body>

--- a/nexus-erp/src/components/ThemeRegistry.tsx
+++ b/nexus-erp/src/components/ThemeRegistry.tsx
@@ -54,14 +54,9 @@ const ThemeRegistry = ({ children, initialTheme }: ThemeRegistryProps) => {
     )
   })
 
-  const [themeId, setThemeIdState] = React.useState<ThemeId>(() => {
-    // On the client, prefer localStorage over the server-side initial value
-    if (typeof window !== 'undefined') {
-      const stored = window.localStorage.getItem('nexus-theme')
-      if (stored) return stored as ThemeId
-    }
-    return (initialTheme as ThemeId) || 'system'
-  })
+  const [themeId, setThemeIdState] = React.useState<ThemeId>(
+    (initialTheme as ThemeId) || 'system',
+  )
 
   // Resolve "system" to light/dark based on OS preference
   const [systemDark, setSystemDark] = React.useState(false)
@@ -78,7 +73,7 @@ const ThemeRegistry = ({ children, initialTheme }: ThemeRegistryProps) => {
 
   const setThemeId = React.useCallback((id: ThemeId) => {
     setThemeIdState(id)
-    window.localStorage.setItem('nexus-theme', id)
+    document.cookie = `nexus-theme=${id}; path=/; max-age=${60 * 60 * 24 * 365}; SameSite=Lax`
   }, [])
 
   // Extend the base theme with NextLink as the global ButtonBase LinkComponent so that


### PR DESCRIPTION
## Summary

- Switch theme persistence from `localStorage` to a **cookie** so the server reads the correct theme and renders `<html data-theme="...">` directly — server and client agree from the first render, no `suppressHydrationWarning` needed
- Remove the blocking localStorage script from `layout.tsx`
- Replace hardcoded light-mode hex colors in `TimesheetCalendar` with a `useStatusConfig()` hook that returns `alpha()`-based palette colors in dark mode
- Replace `grey.50` (near-white, unusable in dark mode) with `action.hover` for weekend cells, week column, and header backgrounds
- Fix invalid `primary.50` hover `bgcolor` with `alpha(primary.main, 0.08)`

## Test plan

- [ ] Load the app with a stored theme cookie (`nexus-dark-pro`) — no hydration warning in the console
- [ ] Load the app with no cookie — defaults to session theme, no warning
- [ ] Change theme via the theme picker — cookie is written, page reload preserves the theme
- [ ] View `/timesheets` in dark mode — calendar status badges, weekend columns, and week column are readable
- [ ] View `/timesheets` in light mode — calendar appearance unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)