### PR TITLE
feat(ci): add dependency freshness guard workflow

### DIFF
--- a/.github/scripts/check-dep-freshness.js
+++ b/.github/scripts/check-dep-freshness.js
@@ -1,0 +1,469 @@
+#!/usr/bin/env node
+// @ts-check
+/**
+ * Dependency Freshness Guard
+ *
+ * Detects production dependencies bumped to versions published fewer than
+ * FRESHNESS_DAYS (default 5) days ago and posts a PR comment + fails CI.
+ *
+ * Environment variables (all provided by the GitHub Actions workflow):
+ *   GITHUB_TOKEN   — for posting PR comments
+ *   PR_NUMBER      — pull request number
+ *   BASE_SHA       — base commit SHA
+ *   REPO           — "owner/repo"
+ *   FRESHNESS_DAYS — optional override (default 5)
+ */
+
+'use strict';
+
+const { execSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const FRESHNESS_DAYS = parseInt(process.env.FRESHNESS_DAYS ?? '5', 10);
+const GITHUB_TOKEN = process.env.GITHUB_TOKEN ?? '';
+const PR_NUMBER = process.env.PR_NUMBER ?? '';
+const BASE_SHA = process.env.BASE_SHA ?? '';
+const REPO = process.env.REPO ?? '';
+const BOT_MARKER = '<!-- dep-freshness-guard -->';
+
+// ---------------------------------------------------------------------------
+// Pure functions (exported for testing)
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a package-lock.json (npm v2/v3) and return a map of
+ * { "package-name": { version: string, dev: boolean } }
+ * Only includes top-level packages (node_modules/<name> entries).
+ *
+ * @param {string} content
+ * @returns {Record<string, { version: string; dev: boolean }>}
+ */
+function parseNpmLockFile(content) {
+  /** @type {Record<string, { version: string; dev: boolean }>} */
+  const result = {};
+  let parsed;
+  try {
+    parsed = JSON.parse(content);
+  } catch {
+    return result;
+  }
+  const packages = parsed.packages ?? {};
+  for (const [key, meta] of Object.entries(packages)) {
+    // Only top-level node_modules entries; skip nested (node_modules/.../node_modules/...)
+    if (!key.startsWith('node_modules/')) continue;
+    const name = key.slice('node_modules/'.length);
+    if (name.includes('/node_modules/')) continue; // nested dep
+    if (typeof meta.version !== 'string') continue;
+    result[name] = {
+      version: meta.version,
+      dev: meta.dev === true || meta.devOptional === true,
+    };
+  }
+  return result;
+}
+
+/**
+ * Parse a yarn.lock file and return a map of
+ * { "package-name": { version: string, dev: boolean } }
+ * dev is always false — yarn.lock doesn't encode dev status per-entry.
+ *
+ * @param {string} content
+ * @returns {Record<string, { version: string; dev: boolean }>}
+ */
+function parseYarnLockFile(content) {
+  /** @type {Record<string, { version: string; dev: boolean }>} */
+  const result = {};
+  // Each block starts with one or more descriptor lines, followed by indented fields.
+  // e.g.:
+  //   "lodash@^4.17.21":
+  //     version "4.17.21"
+  const blocks = content.split(/\n(?=\S)/);
+  for (const block of blocks) {
+    const headerMatch = block.match(/^"?(@?[^@"]+)@/);
+    if (!headerMatch) continue;
+    const name = headerMatch[1].trim();
+    const versionMatch = block.match(/^\s+version\s+"([^"]+)"/m);
+    if (!versionMatch) continue;
+    result[name] = { version: versionMatch[1], dev: false };
+  }
+  return result;
+}
+
+/**
+ * Parse a pnpm-lock.yaml file and return a map of
+ * { "package-name": { version: string, dev: boolean } }
+ *
+ * @param {string} content
+ * @returns {Record<string, { version: string; dev: boolean }>}
+ */
+function parsePnpmLockFile(content) {
+  /** @type {Record<string, { version: string; dev: boolean }>} */
+  const result = {};
+  // pnpm-lock.yaml snapshots section (v6+):
+  //   snapshots:
+  //     lodash@4.17.21:
+  //       ...
+  // or packages section (v5):
+  //   /lodash/4.17.21:
+  const lines = content.split('\n');
+  for (const line of lines) {
+    // v6+ snapshot: "  name@version:" at top level under snapshots
+    const snapshotMatch = line.match(/^  (@?[^@\s]+)@([\d][^\s:]*):$/);
+    if (snapshotMatch) {
+      result[snapshotMatch[1]] = { version: snapshotMatch[2], dev: false };
+      continue;
+    }
+    // v5 package: "  /name/version:"
+    const v5Match = line.match(/^  \/(@?[^/]+(?:\/[^/]+)?)\/([^:]+):$/);
+    if (v5Match) {
+      result[v5Match[1]] = { version: v5Match[2], dev: false };
+    }
+  }
+  return result;
+}
+
+/**
+ * Detect which production dependencies were bumped between base and head.
+ *
+ * @param {Record<string, { version: string; dev: boolean }>} base
+ * @param {Record<string, { version: string; dev: boolean }>} head
+ * @returns {{ name: string; oldVersion: string | null; newVersion: string }[]}
+ */
+function detectBumps(base, head) {
+  /** @type {{ name: string; oldVersion: string | null; newVersion: string }[]} */
+  const bumps = [];
+  for (const [name, headMeta] of Object.entries(head)) {
+    if (headMeta.dev) continue; // skip dev deps
+    const baseMeta = base[name];
+    if (!baseMeta) {
+      // New package added
+      bumps.push({ name, oldVersion: null, newVersion: headMeta.version });
+    } else if (baseMeta.version !== headMeta.version) {
+      // Version changed
+      bumps.push({ name, oldVersion: baseMeta.version, newVersion: headMeta.version });
+    }
+  }
+  return bumps;
+}
+
+/**
+ * Format the PR comment body for flagged packages.
+ *
+ * @param {{ name: string; version: string; publishedAt: string; ageInDays: number }[]} flagged
+ * @param {number} freshnessThreshold
+ * @returns {string}
+ */
+function formatComment(flagged, freshnessThreshold) {
+  if (flagged.length === 0) return '';
+
+  const rows = flagged
+    .map(
+      (p) =>
+        `| \`${p.name}\` | \`${p.version}\` | ${p.publishedAt} | ${p.ageInDays} day${p.ageInDays === 1 ? '' : 's'} |`,
+    )
+    .join('\n');
+
+  return `${BOT_MARKER}
+## Dependency Freshness Warning
+
+The following production ${flagged.length === 1 ? 'dependency was' : 'dependencies were'} bumped to a version published **fewer than ${freshnessThreshold} days ago**. Very new releases may contain undiscovered regressions or breaking changes. Please review carefully before merging.
+
+| Package | Version | Published | Age |
+|---------|---------|-----------|-----|
+${rows}
+
+> To proceed, a team member must dismiss this check override via the GitHub UI, or wait until the packages are older than ${freshnessThreshold} days.
+`;
+}
+
+// ---------------------------------------------------------------------------
+// I/O helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Read a file's content at a specific git commit (or null if it didn't exist).
+ *
+ * @param {string} sha
+ * @param {string} filePath - path relative to repo root
+ * @returns {string | null}
+ */
+function gitShow(sha, filePath) {
+  try {
+    return execSync(`git show "${sha}:${filePath}"`, {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+  } catch {
+    return null; // File didn't exist at that commit
+  }
+}
+
+/**
+ * Find all lock files that changed between base and head.
+ *
+ * @param {string} baseSha
+ * @returns {string[]}
+ */
+function changedLockFiles(baseSha) {
+  const output = execSync(`git diff --name-only "${baseSha}" HEAD`, {
+    encoding: 'utf8',
+  });
+  const changed = output.trim().split('\n').filter(Boolean);
+  return changed.filter((f) =>
+    ['package-lock.json', 'yarn.lock', 'pnpm-lock.yaml'].some((name) => f.endsWith(name)),
+  );
+}
+
+/**
+ * @param {string} lockFilePath
+ * @returns {'npm' | 'yarn' | 'pnpm' | null}
+ */
+function lockFileType(lockFilePath) {
+  const base = path.basename(lockFilePath);
+  if (base === 'package-lock.json') return 'npm';
+  if (base === 'yarn.lock') return 'yarn';
+  if (base === 'pnpm-lock.yaml') return 'pnpm';
+  return null;
+}
+
+/**
+ * @param {string} content
+ * @param {'npm' | 'yarn' | 'pnpm'} type
+ * @returns {Record<string, { version: string; dev: boolean }>}
+ */
+function parseLockFile(content, type) {
+  if (type === 'npm') return parseNpmLockFile(content);
+  if (type === 'yarn') return parseYarnLockFile(content);
+  if (type === 'pnpm') return parsePnpmLockFile(content);
+  return {};
+}
+
+/**
+ * Query the npm registry for the publish date of a specific package@version.
+ * Returns null on network error (graceful degradation).
+ *
+ * @param {string} name
+ * @param {string} version
+ * @returns {Promise<string | null>} ISO date string or null
+ */
+async function fetchPublishDate(name, version) {
+  const encodedName = name.startsWith('@')
+    ? `@${encodeURIComponent(name.slice(1))}`
+    : encodeURIComponent(name);
+  const url = `https://registry.npmjs.org/${encodedName}`;
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 10_000);
+    const res = await fetch(url, { signal: controller.signal });
+    clearTimeout(timeout);
+    if (!res.ok) return null;
+    const data = /** @type {any} */ (await res.json());
+    const time = data.time?.[version];
+    return time ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Find or update a bot comment on the PR. Returns the comment ID if found.
+ *
+ * @param {string} repo
+ * @param {number} prNumber
+ * @returns {Promise<number | null>}
+ */
+async function findBotComment(repo, prNumber) {
+  const url = `https://api.github.com/repos/${repo}/issues/${prNumber}/comments?per_page=100`;
+  const res = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${GITHUB_TOKEN}`,
+      Accept: 'application/vnd.github+json',
+    },
+  });
+  if (!res.ok) return null;
+  const comments = /** @type {any[]} */ (await res.json());
+  const bot = comments.find((c) => c.body?.includes(BOT_MARKER));
+  return bot?.id ?? null;
+}
+
+/**
+ * Create or update the PR comment.
+ *
+ * @param {string} repo
+ * @param {number} prNumber
+ * @param {string} body
+ * @param {number | null} existingCommentId
+ */
+async function upsertComment(repo, prNumber, body, existingCommentId) {
+  if (existingCommentId) {
+    await fetch(`https://api.github.com/repos/${repo}/issues/comments/${existingCommentId}`, {
+      method: 'PATCH',
+      headers: {
+        Authorization: `Bearer ${GITHUB_TOKEN}`,
+        Accept: 'application/vnd.github+json',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ body }),
+    });
+  } else {
+    await fetch(`https://api.github.com/repos/${repo}/issues/${prNumber}/comments`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${GITHUB_TOKEN}`,
+        Accept: 'application/vnd.github+json',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ body }),
+    });
+  }
+}
+
+/**
+ * Delete the bot comment if it exists.
+ *
+ * @param {string} repo
+ * @param {number} commentId
+ */
+async function deleteComment(repo, commentId) {
+  await fetch(`https://api.github.com/repos/${repo}/issues/comments/${commentId}`, {
+    method: 'DELETE',
+    headers: {
+      Authorization: `Bearer ${GITHUB_TOKEN}`,
+      Accept: 'application/vnd.github+json',
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  if (!PR_NUMBER || !BASE_SHA || !REPO) {
+    console.log('Not a pull request context or missing env vars — skipping.');
+    process.exit(0);
+  }
+
+  const lockFiles = changedLockFiles(BASE_SHA);
+  if (lockFiles.length === 0) {
+    console.log('No lock files changed — nothing to check.');
+    process.exit(0);
+  }
+
+  console.log(`Checking lock files: ${lockFiles.join(', ')}`);
+
+  // Collect all bumped production deps across all changed lock files (deduplicated)
+  /** @type {Map<string, { name: string; oldVersion: string | null; newVersion: string }>} */
+  const allBumps = new Map();
+
+  for (const lockFile of lockFiles) {
+    const type = lockFileType(lockFile);
+    if (!type) continue;
+
+    const baseContent = gitShow(BASE_SHA, lockFile);
+    const headContent = fs.existsSync(lockFile) ? fs.readFileSync(lockFile, 'utf8') : null;
+
+    if (!headContent) continue; // Lock file was deleted — nothing to check
+
+    const basePackages = baseContent ? parseLockFile(baseContent, type) : {};
+    const headPackages = parseLockFile(headContent, type);
+    const bumps = detectBumps(basePackages, headPackages);
+
+    for (const bump of bumps) {
+      if (!allBumps.has(bump.name)) {
+        allBumps.set(bump.name, bump);
+      }
+    }
+  }
+
+  if (allBumps.size === 0) {
+    console.log('No production dependency bumps detected.');
+    const existingCommentId = await findBotComment(REPO, parseInt(PR_NUMBER, 10));
+    if (existingCommentId) {
+      await deleteComment(REPO, existingCommentId);
+      console.log('Removed stale freshness warning comment.');
+    }
+    process.exit(0);
+  }
+
+  console.log(`Found ${allBumps.size} bumped production ${allBumps.size === 1 ? 'dep' : 'deps'}:`);
+  for (const bump of allBumps.values()) {
+    console.log(`  ${bump.name}: ${bump.oldVersion ?? '(new)'} → ${bump.newVersion}`);
+  }
+
+  // Query npm registry for publish timestamps
+  const now = Date.now();
+  let registryUnreachable = false;
+
+  /** @type {{ name: string; version: string; publishedAt: string; ageInDays: number }[]} */
+  const flagged = [];
+
+  await Promise.all(
+    Array.from(allBumps.values()).map(async (bump) => {
+      const publishedAt = await fetchPublishDate(bump.name, bump.newVersion);
+      if (publishedAt === null) {
+        registryUnreachable = true;
+        console.warn(`  WARNING: could not fetch publish date for ${bump.name}@${bump.newVersion}`);
+        return;
+      }
+      const publishedMs = new Date(publishedAt).getTime();
+      const ageInDays = Math.floor((now - publishedMs) / (1000 * 60 * 60 * 24));
+      console.log(`  ${bump.name}@${bump.newVersion} — published ${publishedAt} (${ageInDays}d ago)`);
+      if (ageInDays < FRESHNESS_DAYS) {
+        flagged.push({
+          name: bump.name,
+          version: bump.newVersion,
+          publishedAt: publishedAt.slice(0, 10), // YYYY-MM-DD
+          ageInDays,
+        });
+      }
+    }),
+  );
+
+  const existingCommentId = await findBotComment(REPO, parseInt(PR_NUMBER, 10));
+
+  if (registryUnreachable && flagged.length === 0) {
+    // Post a warning but don't fail CI — we couldn't verify
+    const body = `${BOT_MARKER}
+## Dependency Freshness — Registry Unavailable
+
+Could not reach the npm registry to verify the age of bumped dependencies. The freshness check was skipped to avoid blocking the PR on a network issue. Please re-run the check when the registry is available.
+`;
+    await upsertComment(REPO, parseInt(PR_NUMBER, 10), body, existingCommentId);
+    console.log('Registry unreachable — posted warning comment, not failing CI.');
+    process.exit(0);
+  }
+
+  if (flagged.length === 0) {
+    console.log(`All bumped dependencies are older than ${FRESHNESS_DAYS} days. ✓`);
+    if (existingCommentId) {
+      await deleteComment(REPO, existingCommentId);
+      console.log('Removed stale freshness warning comment.');
+    }
+    process.exit(0);
+  }
+
+  // Post/update the warning comment
+  const commentBody = formatComment(flagged, FRESHNESS_DAYS);
+  await upsertComment(REPO, parseInt(PR_NUMBER, 10), commentBody, existingCommentId);
+
+  console.error(`\n❌ ${flagged.length} ${flagged.length === 1 ? 'dependency is' : 'dependencies are'} younger than ${FRESHNESS_DAYS} days. CI check failed.`);
+  process.exit(1);
+}
+
+main().catch((err) => {
+  console.error('Unhandled error in freshness check:', err);
+  process.exit(1);
+});
+
+// Export pure functions for testing
+module.exports = {
+  parseNpmLockFile,
+  parseYarnLockFile,
+  parsePnpmLockFile,
+  parseLockFile,
+  detectBumps,
+  formatComment,
+  BOT_MARKER,
+};

--- a/.github/scripts/check-dep-freshness.test.js
+++ b/.github/scripts/check-dep-freshness.test.js
@@ -1,0 +1,609 @@
+// @ts-check
+import { createRequire } from 'node:module';
+import { describe, it, expect, vi } from 'vitest';
+
+// The script calls main() immediately on load, which calls process.exit().
+// Intercept process.exit before require() so the module-level call does not
+// propagate as an unhandled rejection inside the Vitest process.
+vi.spyOn(process, 'exit').mockImplementation(/** @type {() => never} */ (() => {
+  // intentionally swallow — we only test the pure exported functions
+}));
+
+const require = createRequire(import.meta.url);
+const {
+  parseNpmLockFile,
+  parseYarnLockFile,
+  parsePnpmLockFile,
+  parseLockFile,
+  detectBumps,
+  formatComment,
+  BOT_MARKER,
+} = require('./check-dep-freshness.js');
+
+// ---------------------------------------------------------------------------
+// parseNpmLockFile
+// ---------------------------------------------------------------------------
+
+describe('parseNpmLockFile', () => {
+  it('should return empty object for invalid JSON', () => {
+    expect(parseNpmLockFile('not json at all')).toEqual({});
+    expect(parseNpmLockFile('')).toEqual({});
+    expect(parseNpmLockFile('{')).toEqual({});
+  });
+
+  it('should return empty object for valid JSON without packages key', () => {
+    const content = JSON.stringify({ name: 'my-app', version: '1.0.0', lockfileVersion: 2 });
+    expect(parseNpmLockFile(content)).toEqual({});
+  });
+
+  it('should parse a production dependency (no dev field)', () => {
+    const lockfile = {
+      name: 'my-app',
+      version: '1.0.0',
+      lockfileVersion: 2,
+      packages: {
+        '': { name: 'my-app', version: '1.0.0' },
+        'node_modules/lodash': {
+          version: '4.17.21',
+          resolved: 'https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz',
+        },
+      },
+    };
+    const result = parseNpmLockFile(JSON.stringify(lockfile));
+    expect(result).toEqual({
+      lodash: { version: '4.17.21', dev: false },
+    });
+  });
+
+  it('should mark dev: true for packages with "dev": true', () => {
+    const lockfile = {
+      lockfileVersion: 2,
+      packages: {
+        'node_modules/vitest': { version: '1.0.0', dev: true },
+        'node_modules/express': { version: '4.18.2' },
+      },
+    };
+    const result = parseNpmLockFile(JSON.stringify(lockfile));
+    expect(result.vitest).toEqual({ version: '1.0.0', dev: true });
+    expect(result.express).toEqual({ version: '4.18.2', dev: false });
+  });
+
+  it('should mark dev: true for packages with "devOptional": true', () => {
+    const lockfile = {
+      lockfileVersion: 2,
+      packages: {
+        'node_modules/@types/node': { version: '20.11.0', devOptional: true },
+      },
+    };
+    const result = parseNpmLockFile(JSON.stringify(lockfile));
+    expect(result['@types/node']).toEqual({ version: '20.11.0', dev: true });
+  });
+
+  it('should skip entries that do not start with node_modules/', () => {
+    const lockfile = {
+      lockfileVersion: 2,
+      packages: {
+        '': { name: 'my-app', version: '1.0.0' },
+        'node_modules/express': { version: '4.18.2' },
+        'packages/utils': { version: '0.1.0' },
+      },
+    };
+    const result = parseNpmLockFile(JSON.stringify(lockfile));
+    expect(Object.keys(result)).toEqual(['express']);
+  });
+
+  it('should skip nested node_modules entries (hoisted deduplication artifacts)', () => {
+    const lockfile = {
+      lockfileVersion: 2,
+      packages: {
+        'node_modules/express': { version: '4.18.2' },
+        'node_modules/express/node_modules/qs': { version: '6.11.0' },
+        'node_modules/some-pkg/node_modules/lodash': { version: '3.10.1' },
+      },
+    };
+    const result = parseNpmLockFile(JSON.stringify(lockfile));
+    expect(Object.keys(result)).toEqual(['express']);
+  });
+
+  it('should skip entries without a version string', () => {
+    const lockfile = {
+      lockfileVersion: 2,
+      packages: {
+        'node_modules/has-no-version': { resolved: 'https://example.com' },
+        'node_modules/version-is-number': { version: 1 },
+        'node_modules/express': { version: '4.18.2' },
+      },
+    };
+    const result = parseNpmLockFile(JSON.stringify(lockfile));
+    expect(Object.keys(result)).toEqual(['express']);
+  });
+
+  it('should handle scoped packages at top level', () => {
+    const lockfile = {
+      lockfileVersion: 2,
+      packages: {
+        'node_modules/@scope/pkg': { version: '1.2.3' },
+        'node_modules/@another/tool': { version: '2.0.0', dev: true },
+      },
+    };
+    const result = parseNpmLockFile(JSON.stringify(lockfile));
+    expect(result['@scope/pkg']).toEqual({ version: '1.2.3', dev: false });
+    expect(result['@another/tool']).toEqual({ version: '2.0.0', dev: true });
+  });
+
+  it('should handle a realistic multi-package lockfile (npm v3)', () => {
+    const lockfile = {
+      name: 'my-app',
+      version: '0.1.0',
+      lockfileVersion: 3,
+      packages: {
+        '': {
+          name: 'my-app',
+          version: '0.1.0',
+          dependencies: { express: '^4.18.2' },
+          devDependencies: { vitest: '^1.0.0' },
+        },
+        'node_modules/express': {
+          version: '4.18.2',
+          resolved: 'https://registry.npmjs.org/express/-/express-4.18.2.tgz',
+          integrity: 'sha512-abc',
+        },
+        'node_modules/vitest': {
+          version: '1.0.0',
+          dev: true,
+          resolved: 'https://registry.npmjs.org/vitest/-/vitest-1.0.0.tgz',
+        },
+        'node_modules/@hono/node-server': { version: '1.3.0' },
+      },
+    };
+    const result = parseNpmLockFile(JSON.stringify(lockfile));
+    expect(result).toEqual({
+      express: { version: '4.18.2', dev: false },
+      vitest: { version: '1.0.0', dev: true },
+      '@hono/node-server': { version: '1.3.0', dev: false },
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseYarnLockFile
+// ---------------------------------------------------------------------------
+
+describe('parseYarnLockFile', () => {
+  it('should parse a simple yarn.lock block correctly', () => {
+    const content = `# yarn lockfile v1
+
+lodash@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-abc==
+`;
+    const result = parseYarnLockFile(content);
+    expect(result.lodash).toEqual({ version: '4.17.21', dev: false });
+  });
+
+  it('should handle scoped packages (@scope/name)', () => {
+    const content = `# yarn lockfile v1
+
+"@hono/node-server@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@hono/node-server/-/@hono/node-server-1.3.0.tgz"
+  integrity sha512-xyz==
+`;
+    const result = parseYarnLockFile(content);
+    expect(result['@hono/node-server']).toEqual({ version: '1.3.0', dev: false });
+  });
+
+  it('should return dev: false for all entries (yarn.lock does not encode dev status)', () => {
+    const content = `# yarn lockfile v1
+
+express@^4.18.0:
+  version "4.18.2"
+  resolved "https://registry.yarnpkg.com/express/-/express-4.18.2.tgz"
+  integrity sha512-abc==
+
+vitest@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/vitest/-/vitest-1.0.0.tgz"
+  integrity sha512-def==
+`;
+    const result = parseYarnLockFile(content);
+    expect(result.express.dev).toBe(false);
+    expect(result.vitest.dev).toBe(false);
+  });
+
+  it('should return empty object for empty content', () => {
+    expect(parseYarnLockFile('')).toEqual({});
+  });
+
+  it('should return empty object for content with no version lines', () => {
+    // A block that has a header but no version field is skipped
+    const content = `# yarn lockfile v1\n\n__metadata:\n  version: 6\n`;
+    expect(parseYarnLockFile(content)).toEqual({});
+  });
+
+  it('should parse multiple packages in one file', () => {
+    const content = `# yarn lockfile v1
+
+express@^4.18.0:
+  version "4.18.2"
+  resolved "https://registry.yarnpkg.com/express/-/express-4.18.2.tgz"
+  integrity sha512-abc==
+  dependencies:
+    accepts "~1.3.8"
+
+accepts@~1.3.8:
+  version "1.3.8"
+  resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.8.tgz"
+  integrity sha512-def==
+`;
+    const result = parseYarnLockFile(content);
+    expect(result.express).toEqual({ version: '4.18.2', dev: false });
+    expect(result.accepts).toEqual({ version: '1.3.8', dev: false });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parsePnpmLockFile
+// ---------------------------------------------------------------------------
+
+describe('parsePnpmLockFile', () => {
+  it('should parse v6+ snapshot format (  name@version:)', () => {
+    const content = `lockfileVersion: '6.0'
+
+snapshots:
+  lodash@4.17.21:
+    resolution: {integrity: sha512-abc==}
+
+  express@4.18.2:
+    resolution: {integrity: sha512-def==}
+    dependencies:
+      accepts: 1.3.8
+`;
+    const result = parsePnpmLockFile(content);
+    expect(result.lodash).toEqual({ version: '4.17.21', dev: false });
+    expect(result.express).toEqual({ version: '4.18.2', dev: false });
+  });
+
+  it('should parse v5 format (  /name/version:)', () => {
+    const content = `lockfileVersion: 5.4
+
+packages:
+  /lodash/4.17.21:
+    resolution: {integrity: sha512-abc==}
+    dev: false
+
+  /express/4.18.2:
+    resolution: {integrity: sha512-def==}
+    dev: false
+`;
+    const result = parsePnpmLockFile(content);
+    expect(result.lodash).toEqual({ version: '4.17.21', dev: false });
+    expect(result.express).toEqual({ version: '4.18.2', dev: false });
+  });
+
+  it('should handle scoped packages in v6+ snapshot format', () => {
+    const content = `lockfileVersion: '6.0'
+
+snapshots:
+  @hono/node-server@1.3.0:
+    resolution: {integrity: sha512-abc==}
+
+  @types/node@20.11.0:
+    resolution: {integrity: sha512-def==}
+`;
+    const result = parsePnpmLockFile(content);
+    expect(result['@hono/node-server']).toEqual({ version: '1.3.0', dev: false });
+    expect(result['@types/node']).toEqual({ version: '20.11.0', dev: false });
+  });
+
+  it('should handle scoped packages in v5 format', () => {
+    const content = `lockfileVersion: 5.4
+
+packages:
+  /@hono/node-server/1.3.0:
+    resolution: {integrity: sha512-abc==}
+    dev: false
+`;
+    const result = parsePnpmLockFile(content);
+    expect(result['@hono/node-server']).toEqual({ version: '1.3.0', dev: false });
+  });
+
+  it('should return dev: false for all entries (snapshot section has no per-entry dev flag)', () => {
+    const content = `lockfileVersion: '6.0'
+
+snapshots:
+  lodash@4.17.21:
+    resolution: {integrity: sha512-abc==}
+
+  vitest@1.0.0:
+    resolution: {integrity: sha512-def==}
+`;
+    const result = parsePnpmLockFile(content);
+    expect(result.lodash.dev).toBe(false);
+    expect(result.vitest.dev).toBe(false);
+  });
+
+  it('should return empty object for content with no matching lines', () => {
+    const content = `lockfileVersion: '6.0'\n\nsettings:\n  autoInstallPeers: true\n`;
+    expect(parsePnpmLockFile(content)).toEqual({});
+  });
+
+  it('should ignore nested property lines (indented more than 2 spaces)', () => {
+    const content = `lockfileVersion: '6.0'
+
+snapshots:
+  express@4.18.2:
+    dependencies:
+      accepts: 1.3.8
+    resolution: {integrity: sha512-abc==}
+`;
+    const result = parsePnpmLockFile(content);
+    // Only the snapshot header line should match, not the deeply indented dependency lines
+    expect(Object.keys(result)).toEqual(['express']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseLockFile
+// ---------------------------------------------------------------------------
+
+describe('parseLockFile', () => {
+  it('should dispatch to parseNpmLockFile for type "npm"', () => {
+    const lockfile = {
+      lockfileVersion: 2,
+      packages: {
+        'node_modules/lodash': { version: '4.17.21' },
+      },
+    };
+    const result = parseLockFile(JSON.stringify(lockfile), 'npm');
+    expect(result).toEqual({ lodash: { version: '4.17.21', dev: false } });
+  });
+
+  it('should dispatch to parseYarnLockFile for type "yarn"', () => {
+    const content = [
+      '# yarn lockfile v1',
+      '',
+      'lodash@^4.17.21:',
+      '  version "4.17.21"',
+      '  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz"',
+      '  integrity sha512-abc==',
+      '',
+    ].join('\n');
+    const result = parseLockFile(content, 'yarn');
+    expect(result).toEqual({ lodash: { version: '4.17.21', dev: false } });
+  });
+
+  it('should dispatch to parsePnpmLockFile for type "pnpm"', () => {
+    const content = [
+      "lockfileVersion: '6.0'",
+      '',
+      'snapshots:',
+      '  lodash@4.17.21:',
+      '    resolution: {integrity: sha512-abc==}',
+      '',
+    ].join('\n');
+    const result = parseLockFile(content, 'pnpm');
+    expect(result).toEqual({ lodash: { version: '4.17.21', dev: false } });
+  });
+
+  it('should return empty object for unknown type', () => {
+    // @ts-expect-error intentionally testing invalid types
+    expect(parseLockFile('anything', 'bower')).toEqual({});
+    // @ts-expect-error intentionally testing invalid types
+    expect(parseLockFile('anything', '')).toEqual({});
+    // @ts-expect-error intentionally testing invalid types
+    expect(parseLockFile('anything', 'bun')).toEqual({});
+  });
+});
+
+// ---------------------------------------------------------------------------
+// detectBumps
+// ---------------------------------------------------------------------------
+
+describe('detectBumps', () => {
+  it('should return empty array when nothing changed', () => {
+    const base = {
+      express: { version: '4.18.2', dev: false },
+      lodash: { version: '4.17.21', dev: false },
+    };
+    const head = {
+      express: { version: '4.18.2', dev: false },
+      lodash: { version: '4.17.21', dev: false },
+    };
+    expect(detectBumps(base, head)).toEqual([]);
+  });
+
+  it('should detect a version bump (base v1, head v2)', () => {
+    const base = { express: { version: '4.18.1', dev: false } };
+    const head = { express: { version: '4.18.2', dev: false } };
+    const result = detectBumps(base, head);
+    expect(result).toEqual([{ name: 'express', oldVersion: '4.18.1', newVersion: '4.18.2' }]);
+  });
+
+  it('should detect a newly added production dependency (not in base)', () => {
+    const base = { lodash: { version: '4.17.21', dev: false } };
+    const head = {
+      lodash: { version: '4.17.21', dev: false },
+      zod: { version: '3.22.0', dev: false },
+    };
+    const result = detectBumps(base, head);
+    expect(result).toEqual([{ name: 'zod', oldVersion: null, newVersion: '3.22.0' }]);
+  });
+
+  it('should skip dev dependencies that were bumped (dev: true)', () => {
+    const base = { vitest: { version: '1.0.0', dev: true } };
+    const head = { vitest: { version: '1.5.0', dev: true } };
+    expect(detectBumps(base, head)).toEqual([]);
+  });
+
+  it('should skip newly added dev dependencies', () => {
+    /** @type {Record<string, { version: string; dev: boolean }>} */
+    const base = {};
+    const head = { typescript: { version: '5.4.0', dev: true } };
+    expect(detectBumps(base, head)).toEqual([]);
+  });
+
+  it('should not flag packages removed from head (iteration is over head only)', () => {
+    const base = {
+      lodash: { version: '4.17.21', dev: false },
+      moment: { version: '2.29.4', dev: false },
+    };
+    const head = {
+      lodash: { version: '4.17.21', dev: false },
+      // moment intentionally removed
+    };
+    expect(detectBumps(base, head)).toEqual([]);
+  });
+
+  it('should not flag unchanged packages', () => {
+    const base = {
+      express: { version: '4.18.2', dev: false },
+      lodash: { version: '4.17.21', dev: false },
+    };
+    const head = {
+      express: { version: '4.18.2', dev: false },
+      lodash: { version: '4.17.21', dev: false },
+      zod: { version: '3.22.0', dev: false },
+    };
+    const result = detectBumps(base, head);
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('zod');
+  });
+
+  it('should handle multiple bumps and new packages in one pass', () => {
+    const base = {
+      express: { version: '4.18.1', dev: false },
+      lodash: { version: '4.17.20', dev: false },
+      vitest: { version: '1.0.0', dev: true },
+    };
+    const head = {
+      express: { version: '4.18.2', dev: false },
+      lodash: { version: '4.17.21', dev: false },
+      vitest: { version: '1.5.0', dev: true },
+      zod: { version: '3.22.0', dev: false },
+    };
+    const result = detectBumps(base, head);
+    expect(result).toHaveLength(3);
+    expect(result).toEqual(
+      expect.arrayContaining([
+        { name: 'express', oldVersion: '4.18.1', newVersion: '4.18.2' },
+        { name: 'lodash', oldVersion: '4.17.20', newVersion: '4.17.21' },
+        { name: 'zod', oldVersion: null, newVersion: '3.22.0' },
+      ]),
+    );
+  });
+
+  it('should return empty array when both base and head are empty', () => {
+    expect(detectBumps({}, {})).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatComment
+// ---------------------------------------------------------------------------
+
+describe('formatComment', () => {
+  it('should return empty string for empty flagged array', () => {
+    expect(formatComment([], 5)).toBe('');
+  });
+
+  it('should start with BOT_MARKER', () => {
+    const flagged = [{ name: 'lodash', version: '4.17.21', publishedAt: '2024-01-10', ageInDays: 2 }];
+    const result = formatComment(flagged, 5);
+    expect(result.startsWith(BOT_MARKER)).toBe(true);
+  });
+
+  it('should include the freshnessThreshold in the "fewer than N days ago" warning text', () => {
+    const flagged = [{ name: 'express', version: '4.18.2', publishedAt: '2024-03-01', ageInDays: 3 }];
+    expect(formatComment(flagged, 5)).toContain('fewer than 5 days ago');
+    expect(formatComment(flagged, 7)).toContain('fewer than 7 days ago');
+  });
+
+  it('should include the freshnessThreshold in the "older than N days" footer text', () => {
+    const flagged = [{ name: 'express', version: '4.18.2', publishedAt: '2024-03-01', ageInDays: 3 }];
+    expect(formatComment(flagged, 5)).toContain('older than 5 days');
+    expect(formatComment(flagged, 14)).toContain('older than 14 days');
+  });
+
+  it('should use singular "dependency was" when flagged array has exactly one package', () => {
+    const flagged = [{ name: 'lodash', version: '4.17.21', publishedAt: '2024-01-10', ageInDays: 2 }];
+    const result = formatComment(flagged, 5);
+    expect(result).toContain('dependency was');
+    expect(result).not.toContain('dependencies were');
+  });
+
+  it('should use plural "dependencies were" when flagged array has multiple packages', () => {
+    const flagged = [
+      { name: 'lodash', version: '4.17.21', publishedAt: '2024-01-10', ageInDays: 2 },
+      { name: 'express', version: '4.18.2', publishedAt: '2024-01-11', ageInDays: 1 },
+    ];
+    const result = formatComment(flagged, 5);
+    expect(result).toContain('dependencies were');
+    expect(result).not.toContain('dependency was');
+  });
+
+  it('should use "day" (singular) when ageInDays === 1', () => {
+    const flagged = [{ name: 'zod', version: '3.22.0', publishedAt: '2024-03-10', ageInDays: 1 }];
+    const result = formatComment(flagged, 5);
+    expect(result).toContain('| 1 day |');
+    expect(result).not.toContain('1 days');
+  });
+
+  it('should use "days" (plural) when ageInDays is 0', () => {
+    const flagged = [{ name: 'zod', version: '3.22.0', publishedAt: '2024-03-10', ageInDays: 0 }];
+    const result = formatComment(flagged, 5);
+    expect(result).toContain('| 0 days |');
+  });
+
+  it('should use "days" (plural) when ageInDays is greater than 1', () => {
+    const flagged = [{ name: 'express', version: '4.18.2', publishedAt: '2024-03-09', ageInDays: 3 }];
+    const result = formatComment(flagged, 5);
+    expect(result).toContain('| 3 days |');
+  });
+
+  it('should format a package row correctly in the markdown table', () => {
+    const flagged = [{ name: 'lodash', version: '4.17.21', publishedAt: '2024-01-10', ageInDays: 2 }];
+    const result = formatComment(flagged, 5);
+    expect(result).toContain('| `lodash` | `4.17.21` | 2024-01-10 | 2 days |');
+  });
+
+  it('should format multiple rows in the markdown table', () => {
+    const flagged = [
+      { name: '@scope/pkg', version: '1.2.3', publishedAt: '2024-02-01', ageInDays: 1 },
+      { name: 'express', version: '4.18.2', publishedAt: '2024-02-02', ageInDays: 4 },
+    ];
+    const result = formatComment(flagged, 5);
+    expect(result).toContain('| `@scope/pkg` | `1.2.3` | 2024-02-01 | 1 day |');
+    expect(result).toContain('| `express` | `4.18.2` | 2024-02-02 | 4 days |');
+  });
+
+  it('should include the markdown table header and separator', () => {
+    const flagged = [{ name: 'lodash', version: '4.17.21', publishedAt: '2024-01-10', ageInDays: 2 }];
+    const result = formatComment(flagged, 5);
+    expect(result).toContain('| Package | Version | Published | Age |');
+    expect(result).toContain('|---------|---------|-----------|-----|');
+  });
+
+  it('should include the "Dependency Freshness Warning" heading', () => {
+    const flagged = [{ name: 'lodash', version: '4.17.21', publishedAt: '2024-01-10', ageInDays: 2 }];
+    const result = formatComment(flagged, 5);
+    expect(result).toContain('## Dependency Freshness Warning');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// BOT_MARKER
+// ---------------------------------------------------------------------------
+
+describe('BOT_MARKER', () => {
+  it('should be an HTML comment string', () => {
+    expect(typeof BOT_MARKER).toBe('string');
+    expect(BOT_MARKER.startsWith('<!--')).toBe(true);
+    expect(BOT_MARKER.endsWith('-->')).toBe(true);
+  });
+
+  it('should contain a recognisable identifier so bot comments can be found', () => {
+    expect(BOT_MARKER).toContain('dep-freshness');
+  });
+});

--- a/.github/workflows/dep-freshness.yml
+++ b/.github/workflows/dep-freshness.yml
@@ -1,0 +1,34 @@
+name: Dependency Freshness Guard
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '**/package-lock.json'
+      - '**/yarn.lock'
+      - '**/pnpm-lock.yaml'
+
+jobs:
+  freshness-check:
+    name: Dependency Freshness Check
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Full history needed to diff base vs head lock files
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Check dependency freshness
+        run: node .github/scripts/check-dep-freshness.js
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          REPO: ${{ github.repository }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1583 @@
+{
+  "name": "nexus-workflow",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "nexus-workflow",
+      "devDependencies": {
+        "vitest": "^3.0.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
+      "integrity": "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.4.tgz",
+      "integrity": "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz",
+      "integrity": "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.4.tgz",
+      "integrity": "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz",
+      "integrity": "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz",
+      "integrity": "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz",
+      "integrity": "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz",
+      "integrity": "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz",
+      "integrity": "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz",
+      "integrity": "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz",
+      "integrity": "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz",
+      "integrity": "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz",
+      "integrity": "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz",
+      "integrity": "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz",
+      "integrity": "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz",
+      "integrity": "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.4.tgz",
+      "integrity": "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz",
+      "integrity": "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz",
+      "integrity": "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz",
+      "integrity": "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz",
+      "integrity": "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
+      "integrity": "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz",
+      "integrity": "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz",
+      "integrity": "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
+      "integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz",
+      "integrity": "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz",
+      "integrity": "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz",
+      "integrity": "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz",
+      "integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
+      "integrity": "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz",
+      "integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz",
+      "integrity": "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz",
+      "integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz",
+      "integrity": "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz",
+      "integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz",
+      "integrity": "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
+      "integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz",
+      "integrity": "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
+      "integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz",
+      "integrity": "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz",
+      "integrity": "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
+      "integrity": "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz",
+      "integrity": "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
+      "integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
+      "integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.4",
+        "@esbuild/android-arm": "0.27.4",
+        "@esbuild/android-arm64": "0.27.4",
+        "@esbuild/android-x64": "0.27.4",
+        "@esbuild/darwin-arm64": "0.27.4",
+        "@esbuild/darwin-x64": "0.27.4",
+        "@esbuild/freebsd-arm64": "0.27.4",
+        "@esbuild/freebsd-x64": "0.27.4",
+        "@esbuild/linux-arm": "0.27.4",
+        "@esbuild/linux-arm64": "0.27.4",
+        "@esbuild/linux-ia32": "0.27.4",
+        "@esbuild/linux-loong64": "0.27.4",
+        "@esbuild/linux-mips64el": "0.27.4",
+        "@esbuild/linux-ppc64": "0.27.4",
+        "@esbuild/linux-riscv64": "0.27.4",
+        "@esbuild/linux-s390x": "0.27.4",
+        "@esbuild/linux-x64": "0.27.4",
+        "@esbuild/netbsd-arm64": "0.27.4",
+        "@esbuild/netbsd-x64": "0.27.4",
+        "@esbuild/openbsd-arm64": "0.27.4",
+        "@esbuild/openbsd-x64": "0.27.4",
+        "@esbuild/openharmony-arm64": "0.27.4",
+        "@esbuild/sunos-x64": "0.27.4",
+        "@esbuild/win32-arm64": "0.27.4",
+        "@esbuild/win32-ia32": "0.27.4",
+        "@esbuild/win32-x64": "0.27.4"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
+      "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.59.0",
+        "@rollup/rollup-android-arm64": "4.59.0",
+        "@rollup/rollup-darwin-arm64": "4.59.0",
+        "@rollup/rollup-darwin-x64": "4.59.0",
+        "@rollup/rollup-freebsd-arm64": "4.59.0",
+        "@rollup/rollup-freebsd-x64": "4.59.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.59.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.59.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.59.0",
+        "@rollup/rollup-linux-arm64-musl": "4.59.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.59.0",
+        "@rollup/rollup-linux-loong64-musl": "4.59.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.59.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.59.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.59.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.59.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-musl": "4.59.0",
+        "@rollup/rollup-openbsd-x64": "4.59.0",
+        "@rollup/rollup-openharmony-arm64": "4.59.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.59.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.59.0",
+        "@rollup/rollup-win32-x64-gnu": "4.59.0",
+        "@rollup/rollup-win32-x64-msvc": "4.59.0",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
+      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "nexus-workflow",
   "private": true,
   "scripts": {
-    "lint": "npm run lint --prefix nexus-workflow-core && npm run lint --prefix nexus-workflow-app && npm run lint --prefix nexus-erp"
+    "lint": "npm run lint --prefix nexus-workflow-core && npm run lint --prefix nexus-workflow-app && npm run lint --prefix nexus-erp",
+    "test:scripts": "vitest run --config vitest.scripts.config.js"
+  },
+  "devDependencies": {
+    "vitest": "^3.0.0"
   }
 }

--- a/vitest.scripts.config.js
+++ b/vitest.scripts.config.js
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['.github/scripts/**/*.test.js'],
+    coverage: {
+      provider: 'v8',
+      include: ['.github/scripts/**/*.js'],
+      exclude: ['.github/scripts/**/*.test.js'],
+    },
+  },
+});


### PR DESCRIPTION
## Summary

**CI Workflow**
- New `.github/workflows/dep-freshness.yml` triggers on PRs that touch any lock file (`package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`)
- Checks out the full git history to diff lock files between base and head

**Freshness Check Script**
- `.github/scripts/check-dep-freshness.js` — dependency-free Node.js script that detects bumped production dependencies, queries the npm registry for publish timestamps, and flags any version published fewer than 5 days before the PR
- Posts (or updates) a PR comment table listing flagged packages with name, version, publish date, and age
- Removes the comment when no packages are flagged
- Degrades gracefully if the npm registry is unreachable (posts a warning, does not fail CI)
- Fails the CI status check (exit 1) when any flagged package is found, requiring deliberate manual override to merge

**Tests**
- `.github/scripts/check-dep-freshness.test.js` — 51 Vitest unit tests covering all pure functions (parsers, bump detection, comment formatting)
- Root-level `vitest.scripts.config.js` + `devDependencies.vitest` added to run them via `npm run test:scripts`

Closes #53

## Test plan
- [x] 51 unit tests pass (`npm run test:scripts`)
- [x] Lint passes (0 errors across all packages)
- [x] Script exits 0 with skip message when no env vars set
- [x] Smoke tested: YAML structure valid, all success metrics verified via code paths and tests

## Known limitations
- Branch protection "Required status checks" must be configured separately in GitHub repo settings to enforce the merge gate — the workflow alone posts the failing check but cannot enforce it without that setting.
- `yarn.lock` and `pnpm-lock.yaml` parsing uses basic regex (no external parser dep). Unusual or malformed lock files may not be detected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>