### PR TITLE
ci(nexus-erp): cache Next.js build output between runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,14 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Cache Next.js build
+        uses: actions/cache@v4
+        with:
+          path: nexus-erp/.next/cache
+          key: nextjs-${{ runner.os }}-${{ hashFiles('nexus-erp/package-lock.json') }}-${{ hashFiles('nexus-erp/src/**') }}
+          restore-keys: |
+            nextjs-${{ runner.os }}-${{ hashFiles('nexus-erp/package-lock.json') }}-
+
       - name: Lint
         run: npm run lint
 


### PR DESCRIPTION
## Summary

- Adds `actions/cache@v4` step to the `nexus-erp` CI job to persist `.next/cache` between runs
- Eliminates the "No build cache found" Next.js warning in CI
- Speeds up incremental builds when source files haven't changed

## Cache strategy

- **Key:** `nextjs-{os}-{package-lock hash}-{src/ hash}` — full invalidation on dep or source change
- **Restore key:** `nextjs-{os}-{package-lock hash}-` — partial hit when only source changed

## Test plan

- [ ] CI run on this PR shows "Cache restored" in the Next.js build cache step
- [ ] Second CI run shows a cache hit and faster build time
- [ ] No build cache warning in Next.js output

🤖 Generated with [Claude Code](https://claude.com/claude-code)