### PR TITLE
chore(ci): add manual trigger to dependency freshness guard

### DIFF
--- a/.github/workflows/dep-freshness.yml
+++ b/.github/workflows/dep-freshness.yml
@@ -7,6 +7,7 @@ on:
       - '**/package-lock.json'
       - '**/yarn.lock'
       - '**/pnpm-lock.yaml'
+  workflow_dispatch:
 
 jobs:
   freshness-check:


### PR DESCRIPTION
## Summary

- Adds `workflow_dispatch` to the Dependency Freshness Guard so it can be triggered manually from the GitHub Actions UI without needing a PR with lock file changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)