### PR TITLE
revert(ci): remove workflow_dispatch from dependency freshness guard

### DIFF
--- a/.github/workflows/dep-freshness.yml
+++ b/.github/workflows/dep-freshness.yml
@@ -7,7 +7,6 @@ on:
       - '**/package-lock.json'
       - '**/yarn.lock'
       - '**/pnpm-lock.yaml'
-  workflow_dispatch:
 
 jobs:
   freshness-check:


### PR DESCRIPTION
## Summary

Reverts #62. The freshness guard script relies on PR-only context variables (`PR_NUMBER`, `BASE_SHA`, `github.event.pull_request.*`) — running it via `workflow_dispatch` would fail immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)