### PR TITLE
feat(nexus-workflow-app): Zod 4 request validation on all HTTP routes

### DIFF
--- a/nexus-workflow-app/package-lock.json
+++ b/nexus-workflow-app/package-lock.json
@@ -13,7 +13,7 @@
         "ioredis": "^5.10.0",
         "nexus-workflow-core": "file:../nexus-workflow-core",
         "postgres": "^3.4.5",
-        "zod": "^3.24.2"
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
@@ -6021,9 +6021,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/nexus-workflow-app/package.json
+++ b/nexus-workflow-app/package.json
@@ -22,7 +22,7 @@
     "ioredis": "^5.10.0",
     "nexus-workflow-core": "file:../nexus-workflow-core",
     "postgres": "^3.4.5",
-    "zod": "^3.24.2"
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",

--- a/nexus-workflow-app/src/http/definitions.test.ts
+++ b/nexus-workflow-app/src/http/definitions.test.ts
@@ -364,6 +364,16 @@ describe('definitions HTTP API', () => {
       expect(body.startEventId).toBe('start-1')
     })
 
+    it('400: non-numeric version returns VALIDATION_ERROR', async () => {
+      await store.saveDefinition(makeDefinition())
+      const res = await app.fetch(
+        new Request('http://localhost/definitions/proc-1?version=abc'),
+      )
+      expect(res.status).toBe(400)
+      const body = await res.json()
+      expect(body.error).toBe('VALIDATION_ERROR')
+    })
+
     it('404: unknown id returns 404', async () => {
       const res = await app.fetch(new Request('http://localhost/definitions/does-not-exist'))
       expect(res.status).toBe(404)

--- a/nexus-workflow-app/src/http/definitions.ts
+++ b/nexus-workflow-app/src/http/definitions.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono'
-import { parseBpmn, DefinitionError ,type  StateStore } from 'nexus-workflow-core'
+import { parseBpmn, DefinitionError, type StateStore } from 'nexus-workflow-core'
+import { validationError, versionQuerySchema } from './validation.js'
 
 interface XmlStore {
   saveDefinitionXml(id: string, version: number, xml: string): Promise<void>
@@ -67,8 +68,9 @@ export function createDefinitionsRouter(store: StateStore, xmlStore: XmlStore): 
   // GET /definitions/:id/xml — return raw BPMN XML for a definition
   app.get('/:id/xml', async (c) => {
     const id = c.req.param('id')
-    const versionParam = c.req.query('version')
-    const version = versionParam !== undefined ? Number.parseInt(versionParam, 10) : undefined
+    const versionParsed = versionQuerySchema.safeParse({ version: c.req.query('version') })
+    if (!versionParsed.success) return c.json(validationError(versionParsed.error), 400)
+    const version = versionParsed.data.version
 
     const xml = await xmlStore.getDefinitionXml(id, version)
     if (xml === null) {
@@ -81,8 +83,9 @@ export function createDefinitionsRouter(store: StateStore, xmlStore: XmlStore): 
   // GET /definitions/:id — get latest (or specific version) of a definition
   app.get('/:id', async (c) => {
     const id = c.req.param('id')
-    const versionParam = c.req.query('version')
-    const version = versionParam !== undefined ? Number.parseInt(versionParam, 10) : undefined
+    const versionParsed = versionQuerySchema.safeParse({ version: c.req.query('version') })
+    if (!versionParsed.success) return c.json(validationError(versionParsed.error), 400)
+    const version = versionParsed.data.version
 
     const definition = await store.getDefinition(id, version)
     if (definition === null) {

--- a/nexus-workflow-app/src/http/events.test.ts
+++ b/nexus-workflow-app/src/http/events.test.ts
@@ -102,7 +102,21 @@ describe('events HTTP API', () => {
       const res = await post(app, '/messages', {})
       expect(res.status).toBe(400)
       const body = await res.json() as { error: string }
-      expect(body.error).toBe('INVALID_BODY')
+      expect(body.error).toBe('VALIDATION_ERROR')
+    })
+
+    it('400: missing messageName returns VALIDATION_ERROR', async () => {
+      const res = await post(app, '/messages', {})
+      expect(res.status).toBe(400)
+      const body = await res.json() as { error: string }
+      expect(body.error).toBe('VALIDATION_ERROR')
+    })
+
+    it('400: messageName as empty string returns VALIDATION_ERROR', async () => {
+      const res = await post(app, '/messages', { messageName: '' })
+      expect(res.status).toBe(400)
+      const body = await res.json() as { error: string }
+      expect(body.error).toBe('VALIDATION_ERROR')
     })
 
     it('returns 400 for non-JSON body', async () => {
@@ -152,7 +166,7 @@ describe('events HTTP API', () => {
       const res = await post(app, '/messages', { messageName: 'OrderShipped', correlationValue: 42 })
       expect(res.status).toBe(400)
       const body = await res.json() as { error: string }
-      expect(body.error).toBe('INVALID_BODY')
+      expect(body.error).toBe('VALIDATION_ERROR')
     })
 
     it('returns 400 when body is an array', async () => {
@@ -165,7 +179,7 @@ describe('events HTTP API', () => {
       )
       expect(res.status).toBe(400)
       const body = await res.json() as { error: string }
-      expect(body.error).toBe('INVALID_BODY')
+      expect(body.error).toBe('VALIDATION_ERROR')
     })
   })
 
@@ -210,7 +224,14 @@ describe('events HTTP API', () => {
       const res = await post(app, '/signals', {})
       expect(res.status).toBe(400)
       const body = await res.json() as { error: string }
-      expect(body.error).toBe('INVALID_BODY')
+      expect(body.error).toBe('VALIDATION_ERROR')
+    })
+
+    it('400: missing signalName returns VALIDATION_ERROR', async () => {
+      const res = await post(app, '/signals', {})
+      expect(res.status).toBe(400)
+      const body = await res.json() as { error: string }
+      expect(body.error).toBe('VALIDATION_ERROR')
     })
 
     it('returns 400 for non-JSON body', async () => {
@@ -234,7 +255,7 @@ describe('events HTTP API', () => {
       )
       expect(res.status).toBe(400)
       const body = await res.json() as { error: string }
-      expect(body.error).toBe('INVALID_BODY')
+      expect(body.error).toBe('VALIDATION_ERROR')
     })
 
     it('skips instances where execution throws (RuntimeError) and continues with others', async () => {

--- a/nexus-workflow-app/src/http/events.ts
+++ b/nexus-workflow-app/src/http/events.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono'
 import { execute, RuntimeError, type StateStore, type VariableValue, type EventBus } from 'nexus-workflow-core'
 import { loadEngineState, computeStoreOps, buildUserTaskCreationOps } from './engineHelpers.js'
+import { validationError, deliverMessageBodySchema, broadcastSignalBodySchema } from './validation.js'
 
 // ─── Router ───────────────────────────────────────────────────────────────────
 
@@ -9,26 +10,16 @@ export function createEventsRouter(store: StateStore, eventBus: EventBus): Hono 
 
   // POST /messages — deliver a message to the subscribed instance
   app.post('/messages', async (c) => {
-    let body: unknown
+    let rawBody: unknown
     try {
-      body = await c.req.json()
+      rawBody = await c.req.json()
     } catch {
-      return c.json({ error: 'INVALID_BODY', message: 'Request body is not valid JSON' }, 400)
+      return c.json({ error: 'VALIDATION_ERROR', issues: { formErrors: ['Request body is not valid JSON'], fieldErrors: {} } }, 400)
     }
 
-    if (!body || typeof body !== 'object' || Array.isArray(body)) {
-      return c.json({ error: 'INVALID_BODY', message: 'Request body must be an object' }, 400)
-    }
-
-    const b = body as Record<string, unknown>
-    const { messageName, correlationValue, variables } = b
-
-    if (!messageName || typeof messageName !== 'string') {
-      return c.json({ error: 'INVALID_BODY', message: "'messageName' is required" }, 400)
-    }
-    if (correlationValue !== undefined && typeof correlationValue !== 'string') {
-      return c.json({ error: 'INVALID_BODY', message: "'correlationValue' must be a string" }, 400)
-    }
+    const parsed = deliverMessageBodySchema.safeParse(rawBody)
+    if (!parsed.success) return c.json(validationError(parsed.error), 400)
+    const { messageName, correlationValue, variables } = parsed.data
 
     const subscriptions = await store.findSubscriptions({
       type: 'message',
@@ -77,23 +68,16 @@ export function createEventsRouter(store: StateStore, eventBus: EventBus): Hono 
 
   // POST /signals — broadcast a signal to all subscribed instances
   app.post('/signals', async (c) => {
-    let body: unknown
+    let rawBody: unknown
     try {
-      body = await c.req.json()
+      rawBody = await c.req.json()
     } catch {
-      return c.json({ error: 'INVALID_BODY', message: 'Request body is not valid JSON' }, 400)
+      return c.json({ error: 'VALIDATION_ERROR', issues: { formErrors: ['Request body is not valid JSON'], fieldErrors: {} } }, 400)
     }
 
-    if (!body || typeof body !== 'object' || Array.isArray(body)) {
-      return c.json({ error: 'INVALID_BODY', message: 'Request body must be an object' }, 400)
-    }
-
-    const b = body as Record<string, unknown>
-    const { signalName, variables } = b
-
-    if (!signalName || typeof signalName !== 'string') {
-      return c.json({ error: 'INVALID_BODY', message: "'signalName' is required" }, 400)
-    }
+    const parsed = broadcastSignalBodySchema.safeParse(rawBody)
+    if (!parsed.success) return c.json(validationError(parsed.error), 400)
+    const { signalName, variables } = parsed.data
 
     const subscriptions = await store.findSubscriptions({ type: 'signal', signalName })
 

--- a/nexus-workflow-app/src/http/instances.test.ts
+++ b/nexus-workflow-app/src/http/instances.test.ts
@@ -224,7 +224,7 @@ describe('instances HTTP API', () => {
       )
       expect(res.status).toBe(400)
       const body = await res.json()
-      expect(body.error).toBe('INVALID_BODY')
+      expect(body.error).toBe('VALIDATION_ERROR')
     })
 
     it('400: variables value as an array returns 400', async () => {
@@ -238,7 +238,7 @@ describe('instances HTTP API', () => {
       )
       expect(res.status).toBe(400)
       const body = await res.json()
-      expect(body.error).toBe('INVALID_BODY')
+      expect(body.error).toBe('VALIDATION_ERROR')
     })
 
     it('400: correlationKey that is not a string returns 400', async () => {
@@ -252,7 +252,7 @@ describe('instances HTTP API', () => {
       )
       expect(res.status).toBe(400)
       const body = await res.json()
-      expect(body.error).toBe('INVALID_BODY')
+      expect(body.error).toBe('VALIDATION_ERROR')
     })
 
     it('400: businessKey that is not a string returns 400', async () => {
@@ -266,7 +266,7 @@ describe('instances HTTP API', () => {
       )
       expect(res.status).toBe(400)
       const body = await res.json()
-      expect(body.error).toBe('INVALID_BODY')
+      expect(body.error).toBe('VALIDATION_ERROR')
     })
 
     it('events: ProcessInstanceStarted event is published to the event bus', async () => {
@@ -322,6 +322,37 @@ describe('instances HTTP API', () => {
         new Request('http://localhost/instances/does-not-exist'),
       )
       expect(res.status).toBe(404)
+    })
+  })
+
+  // ─── GET /instances — validation ─────────────────────────────────────────────
+
+  describe('GET /instances — validation', () => {
+    it('400: invalid status value returns VALIDATION_ERROR', async () => {
+      const res = await app.fetch(
+        new Request('http://localhost/instances?status=notavalidstatus'),
+      )
+      expect(res.status).toBe(400)
+      const body = await res.json()
+      expect(body.error).toBe('VALIDATION_ERROR')
+    })
+
+    it('400: non-numeric page returns VALIDATION_ERROR', async () => {
+      const res = await app.fetch(
+        new Request('http://localhost/instances?page=abc'),
+      )
+      expect(res.status).toBe(400)
+      const body = await res.json()
+      expect(body.error).toBe('VALIDATION_ERROR')
+    })
+
+    it('400: non-numeric pageSize returns VALIDATION_ERROR', async () => {
+      const res = await app.fetch(
+        new Request('http://localhost/instances?pageSize=abc'),
+      )
+      expect(res.status).toBe(400)
+      const body = await res.json()
+      expect(body.error).toBe('VALIDATION_ERROR')
     })
   })
 
@@ -511,6 +542,20 @@ describe('instances HTTP API', () => {
         }),
       )
       expect(res.status).toBe(400)
+    })
+
+    it('400: missing type field returns VALIDATION_ERROR', async () => {
+      const { instanceId } = await startUserTaskInstance()
+      const res = await app.fetch(
+        new Request(`http://localhost/instances/${instanceId}/commands`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({}),
+        }),
+      )
+      expect(res.status).toBe(400)
+      const body = await res.json()
+      expect(body.error).toBe('VALIDATION_ERROR')
     })
 
     it('404: unknown instance id returns 404', async () => {

--- a/nexus-workflow-app/src/http/instances.ts
+++ b/nexus-workflow-app/src/http/instances.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono'
 import { execute, RuntimeError, DefinitionError, type StateStore, type EngineCommand, type InstanceQuery, type InstanceStatus, type VariableValue, type EventBus } from 'nexus-workflow-core'
 import { loadEngineState, computeStoreOps, buildUserTaskCreationOps, normalizeVariables, unwrapVariables } from './engineHelpers.js'
+import { validationError, startInstanceBodySchema, listInstancesQuerySchema, instanceStatusSchema, commandBodySchema } from './validation.js'
 
 // ─── Router ───────────────────────────────────────────────────────────────────
 
@@ -25,33 +26,18 @@ export function createInstancesRouter(store: StateStore, eventBus: EventBus): Ho
 
     const contentType = c.req.header('content-type') ?? ''
     if (contentType.includes('application/json')) {
-      let body: unknown
+      let rawBody: unknown
       try {
-        body = await c.req.json()
+        rawBody = await c.req.json()
       } catch {
-        return c.json({ error: 'INVALID_BODY', message: 'Request body is not valid JSON' }, 400)
+        return c.json({ error: 'VALIDATION_ERROR', issues: { formErrors: ['Request body is not valid JSON'], fieldErrors: {} } }, 400)
       }
-      if (body !== null && typeof body === 'object' && !Array.isArray(body)) {
-        const b = body as Record<string, unknown>
-        if (b['variables'] !== undefined) {
-          if (typeof b['variables'] !== 'object' || Array.isArray(b['variables']) || b['variables'] === null) {
-            return c.json({ error: 'INVALID_BODY', message: "'variables' must be an object" }, 400)
-          }
-          variables = normalizeVariables(b['variables'] as Record<string, unknown>)
-        }
-        if (b['correlationKey'] !== undefined) {
-          if (typeof b['correlationKey'] !== 'string') {
-            return c.json({ error: 'INVALID_BODY', message: "'correlationKey' must be a string" }, 400)
-          }
-          correlationKey = b['correlationKey']
-        }
-        if (b['businessKey'] !== undefined) {
-          if (typeof b['businessKey'] !== 'string') {
-            return c.json({ error: 'INVALID_BODY', message: "'businessKey' must be a string" }, 400)
-          }
-          businessKey = b['businessKey']
-        }
-      }
+      const parsed = startInstanceBodySchema.safeParse(rawBody)
+      if (!parsed.success) return c.json(validationError(parsed.error), 400)
+      const b = parsed.data
+      if (b.variables !== undefined) variables = normalizeVariables(b.variables)
+      if (b.correlationKey !== undefined) correlationKey = b.correlationKey
+      if (b.businessKey !== undefined) businessKey = b.businessKey
     }
 
     const command: EngineCommand = {
@@ -82,31 +68,28 @@ export function createInstancesRouter(store: StateStore, eventBus: EventBus): Ho
 
   // GET /instances — list instances with optional filters
   app.get('/instances', async (c) => {
-    const query: InstanceQuery = {
-      page: Number(c.req.query('page') ?? 0),
-      pageSize: Number(c.req.query('pageSize') ?? 20),
-    }
+    const parsed = listInstancesQuerySchema.safeParse(c.req.query())
+    if (!parsed.success) return c.json(validationError(parsed.error), 400)
+    const q = parsed.data
 
-    const qDefinitionId = c.req.query('definitionId')
-    if (qDefinitionId) query.definitionId = qDefinitionId
-    const qCorrelationKey = c.req.query('correlationKey')
-    if (qCorrelationKey) query.correlationKey = qCorrelationKey
-    const qBusinessKey = c.req.query('businessKey')
-    if (qBusinessKey) query.businessKey = qBusinessKey
-    const qStatus = c.req.query('status')
-    if (qStatus) {
-      const statuses = qStatus.split(',').map(x => x.trim()) as InstanceStatus[]
-      const firstStatus = statuses[0]
-      query.status = statuses.length === 1 && firstStatus !== undefined ? firstStatus : statuses
+    const query: InstanceQuery = { page: q.page, pageSize: q.pageSize }
+    if (q.definitionId) query.definitionId = q.definitionId
+    if (q.correlationKey) query.correlationKey = q.correlationKey
+    if (q.businessKey) query.businessKey = q.businessKey
+    if (q.status) {
+      const statuses = q.status.split(',').map(x => x.trim())
+      for (const s of statuses) {
+        const statusParsed = instanceStatusSchema.safeParse(s)
+        if (!statusParsed.success) {
+          return c.json({ error: 'VALIDATION_ERROR', issues: { formErrors: [`Invalid status value: '${s}'`], fieldErrors: {} } }, 400)
+        }
+      }
+      const validStatuses = statuses as InstanceStatus[]
+      const firstStatus = validStatuses[0]
+      query.status = validStatuses.length === 1 && firstStatus !== undefined ? firstStatus : validStatuses
     }
-    const qStartedAfter = c.req.query('startedAfter')
-    if (qStartedAfter) {
-      query.startedAfter = new Date(qStartedAfter)
-    }
-    const qStartedBefore = c.req.query('startedBefore')
-    if (qStartedBefore) {
-      query.startedBefore = new Date(qStartedBefore)
-    }
+    if (q.startedAfter) query.startedAfter = new Date(q.startedAfter)
+    if (q.startedBefore) query.startedBefore = new Date(q.startedBefore)
 
     const result = await store.findInstances(query)
     return c.json(result)
@@ -129,30 +112,17 @@ export function createInstancesRouter(store: StateStore, eventBus: EventBus): Ho
   app.post('/instances/:id/commands', async (c) => {
     const id = c.req.param('id')
 
-    let body: unknown
+    let rawBody: unknown
     try {
-      body = await c.req.json()
+      rawBody = await c.req.json()
     } catch {
-      return c.json({ error: 'INVALID_BODY', message: 'Request body is not valid JSON' }, 400)
+      return c.json({ error: 'VALIDATION_ERROR', issues: { formErrors: ['Request body is not valid JSON'], fieldErrors: {} } }, 400)
     }
 
-    if (!body || typeof body !== 'object' || Array.isArray(body)) {
-      return c.json({ error: 'INVALID_BODY', message: 'Request body must be an object' }, 400)
-    }
+    const parsed = commandBodySchema.safeParse(rawBody)
+    if (!parsed.success) return c.json(validationError(parsed.error), 400)
 
-    const { type } = body as Record<string, unknown>
-
-    const VALID_COMMAND_TYPES = [
-      'CompleteServiceTask', 'FailServiceTask', 'CompleteUserTask',
-      'FireTimer', 'DeliverMessage', 'BroadcastSignal',
-      'SuspendInstance', 'ResumeInstance', 'CancelInstance',
-    ]
-
-    if (!type || typeof type !== 'string' || !VALID_COMMAND_TYPES.includes(type)) {
-      return c.json({ error: 'INVALID_COMMAND', message: `Unknown command type: '${String(type)}'` }, 400)
-    }
-
-    const command = body as EngineCommand
+    const command = parsed.data as EngineCommand
 
     const state = await loadEngineState(store, id)
     if (!state) return c.json({ error: 'NOT_FOUND', message: `Instance '${id}' not found` }, 404)

--- a/nexus-workflow-app/src/http/tasks.test.ts
+++ b/nexus-workflow-app/src/http/tasks.test.ts
@@ -91,6 +91,19 @@ describe('tasks HTTP API', () => {
     app.route('/', createTasksRouter(store, eventBus))
   })
 
+  // ─── GET /tasks — validation ──────────────────────────────────────────────────
+
+  describe('GET /tasks — validation', () => {
+    it('400: invalid status value returns VALIDATION_ERROR', async () => {
+      const res = await app.fetch(
+        new Request('http://localhost/tasks?status=invalidstatus'),
+      )
+      expect(res.status).toBe(400)
+      const body = await res.json()
+      expect(body.error).toBe('VALIDATION_ERROR')
+    })
+  })
+
   // ─── GET /tasks ───────────────────────────────────────────────────────────────
 
   describe('GET /tasks', () => {
@@ -379,6 +392,34 @@ describe('tasks HTTP API', () => {
       expect(res.status).toBe(400)
     })
 
+    it('400: missing completedBy returns VALIDATION_ERROR', async () => {
+      const { taskId } = await startUserTaskProcess(app, store)
+      const res = await app.fetch(
+        new Request(`http://localhost/tasks/${taskId}/complete`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({}),
+        }),
+      )
+      expect(res.status).toBe(400)
+      const body = await res.json()
+      expect(body.error).toBe('VALIDATION_ERROR')
+    })
+
+    it('400: completedBy as empty string returns VALIDATION_ERROR', async () => {
+      const { taskId } = await startUserTaskProcess(app, store)
+      const res = await app.fetch(
+        new Request(`http://localhost/tasks/${taskId}/complete`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ completedBy: '' }),
+        }),
+      )
+      expect(res.status).toBe(400)
+      const body = await res.json()
+      expect(body.error).toBe('VALIDATION_ERROR')
+    })
+
     it('404: unknown task id returns 404', async () => {
       const res = await app.fetch(
         new Request('http://localhost/tasks/does-not-exist/complete', {
@@ -423,7 +464,7 @@ describe('tasks HTTP API', () => {
       )
       expect(res.status).toBe(400)
       const body = await res.json()
-      expect(body.error).toBe('INVALID_BODY')
+      expect(body.error).toBe('VALIDATION_ERROR')
     })
 
     it('422: completing an already-completed task returns 422', async () => {
@@ -501,6 +542,20 @@ describe('tasks HTTP API', () => {
         }),
       )
       expect(res.status).toBe(400)
+    })
+
+    it('400: missing claimedBy returns VALIDATION_ERROR', async () => {
+      const { taskId } = await startUserTaskProcess(app, store)
+      const res = await app.fetch(
+        new Request(`http://localhost/tasks/${taskId}/claim`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({}),
+        }),
+      )
+      expect(res.status).toBe(400)
+      const body = await res.json()
+      expect(body.error).toBe('VALIDATION_ERROR')
     })
 
     it('400: non-JSON body returns 400', async () => {

--- a/nexus-workflow-app/src/http/tasks.ts
+++ b/nexus-workflow-app/src/http/tasks.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono'
-import { execute, RuntimeError, type StateStore, type UserTaskQuery, type UserTaskStatus, type VariableValue, type EventBus } from 'nexus-workflow-core'
+import { execute, RuntimeError, type StateStore, type UserTaskQuery, type VariableValue, type EventBus } from 'nexus-workflow-core'
 import { loadEngineState, computeStoreOps, buildUserTaskCreationOps, normalizeVariables, unwrapVariables } from './engineHelpers.js'
+import { validationError, listTasksQuerySchema, completeTaskBodySchema, claimTaskBodySchema } from './validation.js'
 
 // ─── Router ───────────────────────────────────────────────────────────────────
 
@@ -9,19 +10,15 @@ export function createTasksRouter(store: StateStore, eventBus: EventBus): Hono {
 
   // GET /tasks — list user tasks
   app.get('/tasks', async (c) => {
-    const query: UserTaskQuery = {
-      page: Number(c.req.query('page') ?? 0),
-      pageSize: Number(c.req.query('pageSize') ?? 20),
-    }
+    const parsed = listTasksQuerySchema.safeParse(c.req.query())
+    if (!parsed.success) return c.json(validationError(parsed.error), 400)
+    const q = parsed.data
 
-    const qInstanceId = c.req.query('instanceId')
-    if (qInstanceId) query.instanceId = qInstanceId
-    const qAssignee = c.req.query('assignee')
-    if (qAssignee) query.assignee = qAssignee
-    const qCandidateGroup = c.req.query('candidateGroup')
-    if (qCandidateGroup) query.candidateGroup = qCandidateGroup
-    const qStatus = c.req.query('status')
-    if (qStatus) query.status = qStatus as UserTaskStatus
+    const query: UserTaskQuery = { page: q.page, pageSize: q.pageSize }
+    if (q.instanceId) query.instanceId = q.instanceId
+    if (q.assignee) query.assignee = q.assignee
+    if (q.candidateGroup) query.candidateGroup = q.candidateGroup
+    if (q.status) query.status = q.status
 
     const result = await store.queryUserTasks(query)
     return c.json(result)
@@ -63,21 +60,19 @@ export function createTasksRouter(store: StateStore, eventBus: EventBus): Hono {
       )
     }
 
-    let body: unknown
+    let rawBody: unknown
     try {
-      body = await c.req.json()
+      rawBody = await c.req.json()
     } catch {
-      return c.json({ error: 'INVALID_BODY', message: 'Request body is not valid JSON' }, 400)
+      return c.json({ error: 'VALIDATION_ERROR', issues: { formErrors: ['Request body is not valid JSON'], fieldErrors: {} } }, 400)
     }
 
-    const b = body as Record<string, unknown>
-    const completedBy = b['completedBy']
-    if (!completedBy || typeof completedBy !== 'string') {
-      return c.json({ error: 'INVALID_BODY', message: "'completedBy' is required" }, 400)
-    }
+    const parsed = completeTaskBodySchema.safeParse(rawBody)
+    if (!parsed.success) return c.json(validationError(parsed.error), 400)
+    const { completedBy, outputVariables: rawOutputVariables } = parsed.data
 
-    const outputVariables = b['outputVariables'] !== undefined
-      ? normalizeVariables(b['outputVariables'] as Record<string, unknown>)
+    const outputVariables = rawOutputVariables !== undefined
+      ? normalizeVariables(rawOutputVariables)
       : undefined
 
     const state = await loadEngineState(store, task.instanceId)
@@ -121,17 +116,16 @@ export function createTasksRouter(store: StateStore, eventBus: EventBus): Hono {
     const task = await store.getUserTask(id)
     if (!task) return c.json({ error: 'NOT_FOUND', message: `Task '${id}' not found` }, 404)
 
-    let body: unknown
+    let rawBody: unknown
     try {
-      body = await c.req.json()
+      rawBody = await c.req.json()
     } catch {
-      return c.json({ error: 'INVALID_BODY', message: 'Request body is not valid JSON' }, 400)
+      return c.json({ error: 'VALIDATION_ERROR', issues: { formErrors: ['Request body is not valid JSON'], fieldErrors: {} } }, 400)
     }
 
-    const claimedBy = (body as Record<string, unknown>)['claimedBy']
-    if (!claimedBy || typeof claimedBy !== 'string') {
-      return c.json({ error: 'INVALID_BODY', message: "'claimedBy' is required" }, 400)
-    }
+    const parsed = claimTaskBodySchema.safeParse(rawBody)
+    if (!parsed.success) return c.json(validationError(parsed.error), 400)
+    const { claimedBy } = parsed.data
 
     const updatedTask = { ...task, status: 'claimed' as const, assignee: claimedBy, claimedAt: new Date() }
     await store.executeTransaction([{ op: 'updateUserTask', task: updatedTask }])

--- a/nexus-workflow-app/src/http/validation.ts
+++ b/nexus-workflow-app/src/http/validation.ts
@@ -1,0 +1,84 @@
+import { z } from 'zod'
+
+// ─── Error Helper ─────────────────────────────────────────────────────────────
+
+export function validationError(error: z.ZodError) {
+  return { error: 'VALIDATION_ERROR' as const, issues: error.flatten() }
+}
+
+// ─── Shared ───────────────────────────────────────────────────────────────────
+
+export const paginationSchema = z.object({
+  page: z.coerce.number().int().nonnegative().default(0),
+  pageSize: z.coerce.number().int().positive().default(20),
+})
+
+// ─── Instances ────────────────────────────────────────────────────────────────
+
+export const startInstanceBodySchema = z.object({
+  variables: z.record(z.string(), z.unknown()).optional(),
+  correlationKey: z.string().optional(),
+  businessKey: z.string().optional(),
+})
+
+export const INSTANCE_STATUS_VALUES = ['pending', 'active', 'suspended', 'completed', 'terminated'] as const
+export const instanceStatusSchema = z.enum(INSTANCE_STATUS_VALUES)
+
+export const listInstancesQuerySchema = paginationSchema.extend({
+  definitionId: z.string().optional(),
+  correlationKey: z.string().optional(),
+  businessKey: z.string().optional(),
+  status: z.string().optional(),
+  startedAfter: z.string().optional(),
+  startedBefore: z.string().optional(),
+})
+
+export const COMMAND_TYPES = [
+  'CompleteServiceTask', 'FailServiceTask', 'CompleteUserTask',
+  'FireTimer', 'DeliverMessage', 'BroadcastSignal',
+  'SuspendInstance', 'ResumeInstance', 'CancelInstance',
+] as const
+
+export const commandBodySchema = z.object({
+  type: z.enum(COMMAND_TYPES),
+}).passthrough()
+
+// ─── Tasks ────────────────────────────────────────────────────────────────────
+
+export const USER_TASK_STATUS_VALUES = ['open', 'claimed', 'completed', 'cancelled'] as const
+export const userTaskStatusSchema = z.enum(USER_TASK_STATUS_VALUES)
+
+export const listTasksQuerySchema = paginationSchema.extend({
+  instanceId: z.string().optional(),
+  assignee: z.string().optional(),
+  candidateGroup: z.string().optional(),
+  status: userTaskStatusSchema.optional(),
+})
+
+export const completeTaskBodySchema = z.object({
+  completedBy: z.string().min(1),
+  outputVariables: z.record(z.string(), z.unknown()).optional(),
+})
+
+export const claimTaskBodySchema = z.object({
+  claimedBy: z.string().min(1),
+})
+
+// ─── Events ───────────────────────────────────────────────────────────────────
+
+export const deliverMessageBodySchema = z.object({
+  messageName: z.string().min(1),
+  correlationValue: z.string().optional(),
+  variables: z.record(z.string(), z.unknown()).optional(),
+})
+
+export const broadcastSignalBodySchema = z.object({
+  signalName: z.string().min(1),
+  variables: z.record(z.string(), z.unknown()).optional(),
+})
+
+// ─── Definitions ──────────────────────────────────────────────────────────────
+
+export const versionQuerySchema = z.object({
+  version: z.coerce.number().int().positive().optional(),
+})


### PR DESCRIPTION
## Summary

**Dependency**
- Upgrades `zod` from `^3.24.2` to `^4.3.6`

**Validation Layer**
- Adds `src/http/validation.ts` — centralised Zod schemas for all route groups (instances, tasks, events, definitions) plus a `validationError()` helper that produces `{ error: "VALIDATION_ERROR", issues: {...} }` responses
- All invalid requests now return a consistent HTTP 400 with structured field-level error detail

**Route Handler Cleanup**
- `instances.ts` — replaces manual `typeof` checks and `as` casts on the `POST /definitions/:id/instances` body, `GET /instances` query params (now with `z.coerce.number()` for pagination, enum validation for `status`), and `POST /instances/:id/commands` body
- `tasks.ts` — replaces manual validation on `GET /tasks` query params, `POST /tasks/:id/complete` body (`completedBy` required), and `POST /tasks/:id/claim` body (`claimedBy` required)
- `events.ts` — replaces manual validation on `POST /messages` and `POST /signals` bodies
- `definitions.ts` — replaces `Number.parseInt` with `z.coerce.number()` for the `version` query param

**Tests**
- Updates 10 existing tests to expect `VALIDATION_ERROR` (instead of `INVALID_BODY`)
- Adds 12 new tests covering invalid-input paths: invalid enum values, wrong types, missing required fields, non-numeric pagination params

Closes #59

## Test plan
- [x] 360 tests pass (348 existing + 12 new)
- [x] `npm run typecheck` — zero errors
- [x] `npm run lint` — zero errors (pre-existing console warnings only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>