### PR TITLE
chore(nexus-erp): upgrade Zod from v3 to v4

### DIFF
--- a/nexus-erp/package-lock.json
+++ b/nexus-erp/package-lock.json
@@ -29,7 +29,7 @@
         "next-intl": "^4.8.3",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "zod": "^3.23.8"
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.3.5",
@@ -11642,9 +11642,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/nexus-erp/package.json
+++ b/nexus-erp/package.json
@@ -39,7 +39,7 @@
     "next-intl": "^4.8.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "zod": "^3.23.8"
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.5",

--- a/nexus-erp/src/app/api/departments/[id]/route.ts
+++ b/nexus-erp/src/app/api/departments/[id]/route.ts
@@ -45,7 +45,7 @@ export async function PATCH(
   const body = await req.json()
   const parsed = patchSchema.safeParse(body)
   if (!parsed.success) {
-    return NextResponse.json({ error: parsed.error.errors[0]?.message ?? 'Invalid input' }, { status: 400 })
+    return NextResponse.json({ error: parsed.error.issues[0]?.message ?? 'Invalid input' }, { status: 400 })
   }
 
   const { name, memberIds } = parsed.data

--- a/nexus-erp/src/app/api/departments/route.ts
+++ b/nexus-erp/src/app/api/departments/route.ts
@@ -28,7 +28,7 @@ export async function POST(req: NextRequest) {
   const body = await req.json()
   const parsed = createSchema.safeParse(body)
   if (!parsed.success) {
-    return NextResponse.json({ error: parsed.error.errors[0]?.message ?? 'Invalid input' }, { status: 400 })
+    return NextResponse.json({ error: parsed.error.issues[0]?.message ?? 'Invalid input' }, { status: 400 })
   }
 
   try {

--- a/nexus-erp/src/app/api/employees/[id]/profile-update-requests/route.ts
+++ b/nexus-erp/src/app/api/employees/[id]/profile-update-requests/route.ts
@@ -30,7 +30,7 @@ export async function POST(
   const body = await req.json()
   const parsed = requestSchema.safeParse(body)
   if (!parsed.success) {
-    return NextResponse.json({ error: parsed.error.errors[0]?.message ?? 'Invalid input' }, { status: 400 })
+    return NextResponse.json({ error: parsed.error.issues[0]?.message ?? 'Invalid input' }, { status: 400 })
   }
 
   const contactData = {

--- a/nexus-erp/src/app/api/employees/[id]/route.ts
+++ b/nexus-erp/src/app/api/employees/[id]/route.ts
@@ -124,7 +124,7 @@ export async function PATCH(
   const body = await req.json()
   const parsed = patchSchema.safeParse(body)
   if (!parsed.success) {
-    return NextResponse.json({ error: parsed.error.errors[0]?.message ?? 'Invalid input' }, { status: 400 })
+    return NextResponse.json({ error: parsed.error.issues[0]?.message ?? 'Invalid input' }, { status: 400 })
   }
 
   // Employees may only update their own contact fields

--- a/nexus-erp/src/app/api/employees/route.ts
+++ b/nexus-erp/src/app/api/employees/route.ts
@@ -45,7 +45,7 @@ export async function POST(req: NextRequest) {
   const body = await req.json()
   const parsed = registerSchema.safeParse(body)
   if (!parsed.success) {
-    return NextResponse.json({ error: parsed.error.errors[0]?.message ?? 'Invalid input' }, { status: 400 })
+    return NextResponse.json({ error: parsed.error.issues[0]?.message ?? 'Invalid input' }, { status: 400 })
   }
 
   const { email, password, fullName, departmentId, managerId, role, hireDate, phone, street, city, state, postalCode, country } = parsed.data

--- a/nexus-erp/src/app/api/internal/organizations/[id]/status/route.ts
+++ b/nexus-erp/src/app/api/internal/organizations/[id]/status/route.ts
@@ -25,7 +25,7 @@ export async function PATCH(
   const body = await req.json()
   const parsed = bodySchema.safeParse(body)
   if (!parsed.success) {
-    return NextResponse.json({ error: parsed.error.errors[0]?.message ?? 'Invalid input' }, { status: 400 })
+    return NextResponse.json({ error: parsed.error.issues[0]?.message ?? 'Invalid input' }, { status: 400 })
   }
 
   const existing = await db.organization.findUnique({ where: { id }, select: { id: true } })

--- a/nexus-erp/src/app/api/organizations/[id]/contact/route.ts
+++ b/nexus-erp/src/app/api/organizations/[id]/contact/route.ts
@@ -34,7 +34,7 @@ export async function PATCH(
   const body = await req.json()
   const parsed = patchSchema.safeParse(body)
   if (!parsed.success) {
-    return NextResponse.json({ error: parsed.error.errors[0]?.message ?? 'Invalid input' }, { status: 400 })
+    return NextResponse.json({ error: parsed.error.issues[0]?.message ?? 'Invalid input' }, { status: 400 })
   }
 
   // Normalize empty strings to null

--- a/nexus-erp/src/app/api/organizations/[id]/decision/route.ts
+++ b/nexus-erp/src/app/api/organizations/[id]/decision/route.ts
@@ -52,7 +52,7 @@ export async function POST(
   const body = await req.json()
   const parsed = bodySchema.safeParse(body)
   if (!parsed.success) {
-    return NextResponse.json({ error: parsed.error.errors[0]?.message ?? 'Invalid input' }, { status: 400 })
+    return NextResponse.json({ error: parsed.error.issues[0]?.message ?? 'Invalid input' }, { status: 400 })
   }
 
   const { decision, rejectionReason } = parsed.data

--- a/nexus-erp/src/app/api/organizations/[id]/owner/route.ts
+++ b/nexus-erp/src/app/api/organizations/[id]/owner/route.ts
@@ -20,7 +20,7 @@ export async function PATCH(
   const body = await req.json()
   const parsed = patchSchema.safeParse(body)
   if (!parsed.success) {
-    return NextResponse.json({ error: parsed.error.errors[0]?.message ?? 'Invalid input' }, { status: 400 })
+    return NextResponse.json({ error: parsed.error.issues[0]?.message ?? 'Invalid input' }, { status: 400 })
   }
 
   const existing = await db.organization.findUnique({ where: { id }, select: { id: true } })

--- a/nexus-erp/src/app/api/organizations/[id]/request-status-change/route.ts
+++ b/nexus-erp/src/app/api/organizations/[id]/request-status-change/route.ts
@@ -39,7 +39,7 @@ export async function POST(
   const body = await req.json()
   const parsed = bodySchema.safeParse(body)
   if (!parsed.success) {
-    return NextResponse.json({ error: parsed.error.errors[0]?.message ?? 'Invalid input' }, { status: 400 })
+    return NextResponse.json({ error: parsed.error.issues[0]?.message ?? 'Invalid input' }, { status: 400 })
   }
 
   const { requestedStatus, statusChangeReason } = parsed.data

--- a/nexus-erp/src/app/api/organizations/[id]/route.ts
+++ b/nexus-erp/src/app/api/organizations/[id]/route.ts
@@ -49,7 +49,7 @@ export async function PATCH(
   const body = await req.json()
   const parsed = patchSchema.safeParse(body)
   if (!parsed.success) {
-    return NextResponse.json({ error: parsed.error.errors[0]?.message ?? 'Invalid input' }, { status: 400 })
+    return NextResponse.json({ error: parsed.error.issues[0]?.message ?? 'Invalid input' }, { status: 400 })
   }
 
   const updated = await db.organization.update({

--- a/nexus-erp/src/app/api/organizations/route.ts
+++ b/nexus-erp/src/app/api/organizations/route.ts
@@ -43,7 +43,7 @@ export async function POST(req: NextRequest) {
   const body = await req.json()
   const parsed = createSchema.safeParse(body)
   if (!parsed.success) {
-    return NextResponse.json({ error: parsed.error.errors[0]?.message ?? 'Invalid input' }, { status: 400 })
+    return NextResponse.json({ error: parsed.error.issues[0]?.message ?? 'Invalid input' }, { status: 400 })
   }
 
   const { name, legalName, industry, taxId, registrationNo, email, phone, website, street, city, state, postalCode, country, ownerId } = parsed.data

--- a/nexus-erp/src/app/api/tasks/[id]/complete/route.ts
+++ b/nexus-erp/src/app/api/tasks/[id]/complete/route.ts
@@ -22,7 +22,7 @@ export async function POST(
   const body = await req.json()
   const parsed = completeSchema.safeParse(body)
   if (!parsed.success) {
-    return NextResponse.json({ error: parsed.error.errors[0]?.message ?? 'Invalid input' }, { status: 400 })
+    return NextResponse.json({ error: parsed.error.issues[0]?.message ?? 'Invalid input' }, { status: 400 })
   }
 
   const { decision, rejectionReason } = parsed.data

--- a/nexus-erp/src/app/api/timesheets/[id]/entries/[entryId]/route.ts
+++ b/nexus-erp/src/app/api/timesheets/[id]/entries/[entryId]/route.ts
@@ -37,7 +37,7 @@ export async function PUT(
   const body = await req.json()
   const parsed = updateSchema.safeParse(body)
   if (!parsed.success) {
-    return NextResponse.json({ error: parsed.error.errors[0]?.message ?? 'Invalid input' }, { status: 400 })
+    return NextResponse.json({ error: parsed.error.issues[0]?.message ?? 'Invalid input' }, { status: 400 })
   }
 
   const entry = await db.timesheetEntry.update({

--- a/nexus-erp/src/app/api/timesheets/[id]/entries/route.ts
+++ b/nexus-erp/src/app/api/timesheets/[id]/entries/route.ts
@@ -32,7 +32,7 @@ export async function POST(
   const body = await req.json()
   const parsed = createSchema.safeParse(body)
   if (!parsed.success) {
-    return NextResponse.json({ error: parsed.error.errors[0]?.message ?? 'Invalid input' }, { status: 400 })
+    return NextResponse.json({ error: parsed.error.issues[0]?.message ?? 'Invalid input' }, { status: 400 })
   }
 
   const entry = await db.timesheetEntry.create({

--- a/nexus-erp/src/app/api/timesheets/route.ts
+++ b/nexus-erp/src/app/api/timesheets/route.ts
@@ -51,7 +51,7 @@ export async function POST(req: NextRequest) {
   const body = await req.json()
   const parsed = createSchema.safeParse(body)
   if (!parsed.success) {
-    return NextResponse.json({ error: parsed.error.errors[0]?.message ?? 'Invalid input' }, { status: 400 })
+    return NextResponse.json({ error: parsed.error.issues[0]?.message ?? 'Invalid input' }, { status: 400 })
   }
 
   try {

--- a/nexus-erp/src/app/api/users/[id]/groups/route.ts
+++ b/nexus-erp/src/app/api/users/[id]/groups/route.ts
@@ -21,7 +21,7 @@ export async function PUT(
   const body = await req.json()
   const parsed = putSchema.safeParse(body)
   if (!parsed.success) {
-    return NextResponse.json({ error: parsed.error.errors[0]?.message ?? 'Invalid input' }, { status: 400 })
+    return NextResponse.json({ error: parsed.error.issues[0]?.message ?? 'Invalid input' }, { status: 400 })
   }
 
   const { groupIds } = parsed.data

--- a/nexus-erp/src/app/api/users/[id]/permissions/route.ts
+++ b/nexus-erp/src/app/api/users/[id]/permissions/route.ts
@@ -40,7 +40,7 @@ export async function PUT(
   const body = await req.json()
   const parsed = putSchema.safeParse(body)
   if (!parsed.success) {
-    return NextResponse.json({ error: parsed.error.errors[0]?.message ?? 'Invalid input' }, { status: 400 })
+    return NextResponse.json({ error: parsed.error.issues[0]?.message ?? 'Invalid input' }, { status: 400 })
   }
 
   const { permissionKeys } = parsed.data

--- a/nexus-erp/src/app/api/users/[id]/preferences/route.ts
+++ b/nexus-erp/src/app/api/users/[id]/preferences/route.ts
@@ -30,7 +30,7 @@ export async function PATCH(
   const body = await req.json()
   const parsed = patchSchema.safeParse(body)
   if (!parsed.success) {
-    return NextResponse.json({ error: parsed.error.errors[0]?.message ?? 'Invalid input' }, { status: 400 })
+    return NextResponse.json({ error: parsed.error.issues[0]?.message ?? 'Invalid input' }, { status: 400 })
   }
 
   if (!parsed.data.theme && !parsed.data.locale) {


### PR DESCRIPTION
## Summary

**Dependency**
- Upgrades `zod` from `^3.23.8` to `^4.3.6` in `nexus-erp`

**Schema / Route Handlers**
- The only breaking API change in Zod 4 affecting this codebase: `ZodError.errors` was removed — replaced all 19 occurrences of `parsed.error.errors[0]?.message` with `parsed.error.issues[0]?.message` across all API route files
- No schema syntax changes required — all patterns used (`.min()`, `.optional()`, `.nullable()`, `.nullish()`, `.or()`, `.enum()`, `.regex()`) are fully compatible with Zod 4

Closes #58

## Test plan
- [x] 508 tests pass (no regressions)
- [x] `npm run typecheck` — zero errors
- [x] `npm run lint` — zero errors (pre-existing console warnings only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>