### PR TITLE
chore: safe dependency updates (patch/minor)

### DIFF
--- a/nexus-erp/package-lock.json
+++ b/nexus-erp/package-lock.json
@@ -20,7 +20,7 @@
         "@prisma/adapter-pg": "^7.5.0",
         "@prisma/client": "^7.5.0",
         "bcryptjs": "^2.4.3",
-        "bpmn-auto-layout": "^1.2.0",
+        "bpmn-auto-layout": "^1.3.0",
         "bpmn-js": "^18.13.1",
         "dayjs": "^1.11.20",
         "ioredis": "^5.10.0",
@@ -41,7 +41,7 @@
         "@types/node": "^22.0.0",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
-        "@vitest/coverage-v8": "^4.0.18",
+        "@vitest/coverage-v8": "^4.1.0",
         "@vitest/eslint-plugin": "^1.6.12",
         "eslint": "^9.39.4",
         "eslint-config-next": "^16.1.6",
@@ -54,7 +54,7 @@
         "tsx": "^4.19.2",
         "typescript": "^5.6.3",
         "typescript-eslint": "^8.57.0",
-        "vitest": "^4.0.18"
+        "vitest": "^4.1.0"
       }
     },
     "node_modules/@acemir/cssom": {

--- a/nexus-erp/package.json
+++ b/nexus-erp/package.json
@@ -30,7 +30,7 @@
     "@prisma/adapter-pg": "^7.5.0",
     "@prisma/client": "^7.5.0",
     "bcryptjs": "^2.4.3",
-    "bpmn-auto-layout": "^1.2.0",
+    "bpmn-auto-layout": "^1.3.0",
     "bpmn-js": "^18.13.1",
     "dayjs": "^1.11.20",
     "ioredis": "^5.10.0",
@@ -51,7 +51,7 @@
     "@types/node": "^22.0.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
-    "@vitest/coverage-v8": "^4.0.18",
+    "@vitest/coverage-v8": "^4.1.0",
     "@vitest/eslint-plugin": "^1.6.12",
     "eslint": "^9.39.4",
     "eslint-config-next": "^16.1.6",
@@ -64,6 +64,6 @@
     "tsx": "^4.19.2",
     "typescript": "^5.6.3",
     "typescript-eslint": "^8.57.0",
-    "vitest": "^4.0.18"
+    "vitest": "^4.1.0"
   }
 }

--- a/nexus-workflow-app/package-lock.json
+++ b/nexus-workflow-app/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@hono/node-server": "^1.13.7",
-        "hono": "^4.7.7",
+        "hono": "^4.12.8",
         "ioredis": "^5.10.0",
         "nexus-workflow-core": "file:../nexus-workflow-core",
         "postgres": "^3.4.5",
@@ -17,7 +17,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
-        "@types/node": "^25.3.5",
+        "@types/node": "^25.5.0",
         "@vitest/coverage-v8": "^4.1.0",
         "@vitest/eslint-plugin": "^1.6.12",
         "eslint": "^9.39.4",
@@ -34,11 +34,11 @@
     "../nexus-workflow-core": {
       "version": "0.1.0",
       "dependencies": {
-        "fast-xml-parser": "^5.5.3"
+        "fast-xml-parser": "^5.5.5"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
-        "@types/node": "^25.3.5",
+        "@types/node": "^25.5.0",
         "@vitest/coverage-v8": "^4.1.0",
         "@vitest/eslint-plugin": "^1.6.12",
         "eslint": "^9.39.4",

--- a/nexus-workflow-app/package.json
+++ b/nexus-workflow-app/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@hono/node-server": "^1.13.7",
-    "hono": "^4.7.7",
+    "hono": "^4.12.8",
     "ioredis": "^5.10.0",
     "nexus-workflow-core": "file:../nexus-workflow-core",
     "postgres": "^3.4.5",
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
-    "@types/node": "^25.3.5",
+    "@types/node": "^25.5.0",
     "@vitest/coverage-v8": "^4.1.0",
     "@vitest/eslint-plugin": "^1.6.12",
     "eslint": "^9.39.4",

--- a/nexus-workflow-core/package-lock.json
+++ b/nexus-workflow-core/package-lock.json
@@ -8,11 +8,11 @@
       "name": "nexus-workflow-core",
       "version": "0.1.0",
       "dependencies": {
-        "fast-xml-parser": "^5.5.3"
+        "fast-xml-parser": "^5.5.5"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
-        "@types/node": "^25.3.5",
+        "@types/node": "^25.5.0",
         "@vitest/coverage-v8": "^4.1.0",
         "@vitest/eslint-plugin": "^1.6.12",
         "eslint": "^9.39.4",

--- a/nexus-workflow-core/package.json
+++ b/nexus-workflow-core/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
-    "@types/node": "^25.3.5",
+    "@types/node": "^25.5.0",
     "@vitest/coverage-v8": "^4.1.0",
     "@vitest/eslint-plugin": "^1.6.12",
     "eslint": "^9.39.4",
@@ -37,6 +37,6 @@
     "vitest": "^4.1.0"
   },
   "dependencies": {
-    "fast-xml-parser": "^5.5.3"
+    "fast-xml-parser": "^5.5.5"
   }
 }


### PR DESCRIPTION
## Summary

Patch and minor dependency updates across all three packages — no breaking changes, all test suites green.

**nexus-workflow-core**
- `fast-xml-parser` 5.5.3 → 5.5.5
- `@types/node` 25.3.5 → 25.5.0

**nexus-workflow-app**
- `hono` 4.12.5 → 4.12.8 — also resolves Dependabot alert #8 (serveStatic vulnerability, patched in 4.12.4)
- `@types/node` 25.3.5 → 25.5.0

**nexus-erp**
- `vitest` + `@vitest/coverage-v8` 4.0.18 → 4.1.0
- `bpmn-auto-layout` 1.2.0 → 1.3.0

## Intentionally left out
- `eslint` v9 → v10: blocked by `eslint-plugin-import` not declaring v10 support yet
- `bcryptjs` v2 → v3: major bump, needs its own focused PR
- `@types/node` 22 → 25 (nexus-erp): major jump, needs its own PR
- `next-auth`: intentionally on v5 beta, npm showing v4 as "latest" is misleading

## Test plan
- [x] nexus-workflow-core: 372 tests pass
- [x] nexus-workflow-app: 360 tests pass
- [x] nexus-erp: 508 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>