### PR TITLE
fix(ci): replace broken plugin-based PR review with direct prompt

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,12 +3,6 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
 
 jobs:
   claude-review:
@@ -26,16 +20,15 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 0
 
       - name: Run Claude Code Review
         id: claude-review
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
-          plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
-
+          prompt: |
+            Review the changes in this pull request.
+            Flag bugs, security issues, and deviations from the project conventions described in CLAUDE.md.
+            Post your findings as inline review comments on the relevant lines.
+            If the code looks good, post a brief summary comment on the PR confirming the review is complete.


### PR DESCRIPTION
## Summary

The `claude-code-review` workflow was running successfully (20 turns, ~$1.23) but posting no comments due to the broken plugin configuration:
- `plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'` — wrong URL
- `plugins: 'code-review@claude-code-plugins'` — silently failed
- `permission_denials_count: 1` in every run — something was being blocked

**Fix:** remove the plugin approach entirely and use a plain `prompt` that directly instructs Claude to post inline review comments and a summary.

Also added `fetch-depth: 0` so Claude has full git history for context.

## Test plan
- [ ] Merge this PR → triggers the workflow on itself (meta-review)
- [ ] Open any new PR and confirm Claude posts review comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>