### PR TITLE
feat(nexus-erp): emit CONFLICT audit entry on expense submission 409 path

### DIFF
--- a/nexus-erp/prisma/migrations/20260316230000_add_conflict_audit_action/migration.sql
+++ b/nexus-erp/prisma/migrations/20260316230000_add_conflict_audit_action/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "AuditAction" ADD VALUE 'CONFLICT';

--- a/nexus-erp/prisma/schema.prisma
+++ b/nexus-erp/prisma/schema.prisma
@@ -339,6 +339,7 @@ enum AuditAction {
   CREATE
   UPDATE
   DELETE
+  CONFLICT
 }
 
 model AuditLog {

--- a/nexus-erp/src/app/api/expenses/[id]/route.test.ts
+++ b/nexus-erp/src/app/api/expenses/[id]/route.test.ts
@@ -451,6 +451,15 @@ describe('PATCH /api/expenses/[id]', () => {
     expect(res._status).toBe(409)
     expect(mockExpenseReportFindUniqueInTx).not.toHaveBeenCalled()
     expect(mockCancelInstance).toHaveBeenCalledWith('wf-instance-1')
+    expect(mockCreateAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entityType: 'ExpenseReport',
+        entityId: 'exp-1',
+        action: 'CONFLICT',
+        before: { status: 'REJECTED' },
+        after: expect.objectContaining({ conflict: true, workflowInstanceId: 'wf-instance-1' }),
+      }),
+    )
   })
 
   it('should still return 409 when cancelInstance fails (best-effort)', async () => {
@@ -463,6 +472,20 @@ describe('PATCH /api/expenses/[id]', () => {
 
     expect(res._status).toBe(409)
     expect(mockCancelInstance).toHaveBeenCalledWith('wf-instance-1')
+    expect(mockCreateAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'CONFLICT' }),
+    )
+  })
+
+  it('should still return 409 when createAuditLog fails on conflict path (best-effort)', async () => {
+    mockAuth.mockResolvedValue(SESSION)
+    mockExpenseReportFindUnique.mockResolvedValue({ ...BASE_REPORT, status: 'REJECTED' })
+    mockExpenseReportUpdateMany.mockResolvedValue({ count: 0 })
+    mockCreateAuditLog.mockRejectedValue(new Error('db unavailable'))
+
+    const res = await PATCH(makePatchRequest({ status: 'SUBMITTED' }), PARAMS)
+
+    expect(res._status).toBe(409)
   })
 
   it('should not start workflow when only line items are patched', async () => {

--- a/nexus-erp/src/app/api/expenses/[id]/route.ts
+++ b/nexus-erp/src/app/api/expenses/[id]/route.ts
@@ -179,6 +179,22 @@ export async function PATCH(
         console.error(`[expense] failed to cancel orphaned workflow instance ${workflowInstanceId}:`, err)
       }
     }
+    // Emit a CONFLICT audit entry so there is a searchable record that a SUBMIT
+    // was attempted and lost the race. Written outside the (rolled-back) transaction.
+    try {
+      await createAuditLog({
+        db,
+        entityType: 'ExpenseReport',
+        entityId: id,
+        action: 'CONFLICT',
+        actorId,
+        actorName,
+        before: { status: report.status },
+        after: { conflict: true, workflowInstanceId: workflowInstanceId ?? null },
+      })
+    } catch (err) {
+      console.error('[expense-submit] failed to write conflict audit log:', err)
+    }
     return NextResponse.json({ error: 'Conflict — expense was already submitted' }, { status: 409 })
   }
 


### PR DESCRIPTION
Closes #79

Add CONFLICT to the AuditAction enum and write a best-effort audit log entry when a SUBMIT loses the DB race (updateMany count=0). This gives a searchable audit trail for orphaned-instance incidents without affecting the 409 response or correctness.

Generated with [Claude Code](https://claude.ai/code)