### PR TITLE
feat: expense list page & navigation (#93)

### DIFF
--- a/nexus-erp/messages/en.json
+++ b/nexus-erp/messages/en.json
@@ -26,7 +26,8 @@
       "groups": "Groups",
       "settings": "Settings",
       "auditLog": "Audit Log",
-      "messages": "Messages"
+      "messages": "Messages",
+      "expenses": "Expenses"
     },
     "expandSidebar": "Expand sidebar",
     "collapseSidebar": "Collapse sidebar"
@@ -444,6 +445,25 @@
       "instanceNotFound": "Instance \"{instanceId}\" not found.",
       "fetchFailed": "Failed to fetch events.",
       "networkError": "Network error."
+    }
+  },
+  "expenses": {
+    "title": "Expense Reports",
+    "noExpenses": "No expense reports found.",
+    "view": "View",
+    "columns": {
+      "employee": "Employee",
+      "date": "Date",
+      "total": "Total",
+      "status": "Status"
+    },
+    "status": {
+      "DRAFT": "Draft",
+      "SUBMITTED": "Submitted",
+      "APPROVED_MANAGER": "Manager Approved",
+      "APPROVED_ACCOUNTING": "Accounting Approved",
+      "REJECTED": "Rejected",
+      "REIMBURSED": "Reimbursed"
     }
   },
   "auditLog": {

--- a/nexus-erp/messages/es.json
+++ b/nexus-erp/messages/es.json
@@ -26,7 +26,8 @@
       "groups": "Grupos",
       "settings": "Configuración",
       "auditLog": "Registro de auditoría",
-      "messages": "Mensajes"
+      "messages": "Mensajes",
+      "expenses": "Gastos"
     },
     "expandSidebar": "Expandir barra lateral",
     "collapseSidebar": "Contraer barra lateral"
@@ -230,6 +231,25 @@
     "linkedTimesheet": "Hoja de tiempo del {weekStart}",
     "unknownUser": "Usuario desconocido",
     "unreadBadge": "Mensajes no le\u00eddos"
+  },
+  "expenses": {
+    "title": "Informes de gastos",
+    "noExpenses": "No se encontraron informes de gastos.",
+    "view": "Ver",
+    "columns": {
+      "employee": "Empleado",
+      "date": "Fecha",
+      "total": "Total",
+      "status": "Estado"
+    },
+    "status": {
+      "DRAFT": "Borrador",
+      "SUBMITTED": "Enviado",
+      "APPROVED_MANAGER": "Aprobado por el manager",
+      "APPROVED_ACCOUNTING": "Aprobado por contabilidad",
+      "REJECTED": "Rechazado",
+      "REIMBURSED": "Reembolsado"
+    }
   },
   "auditLog": {
     "title": "Registro de auditoría",

--- a/nexus-erp/messages/fr.json
+++ b/nexus-erp/messages/fr.json
@@ -26,7 +26,8 @@
       "groups": "Groupes",
       "settings": "Paramètres",
       "auditLog": "Journal d’audit",
-      "messages": "Messagerie"
+      "messages": "Messagerie",
+      "expenses": "Notes de frais"
     },
     "expandSidebar": "Développer la barre latérale",
     "collapseSidebar": "Réduire la barre latérale"
@@ -444,6 +445,25 @@
       "instanceNotFound": "Instance \"{instanceId}\" introuvable.",
       "fetchFailed": "Impossible de récupérer les événements.",
       "networkError": "Erreur réseau."
+    }
+  },
+  "expenses": {
+    "title": "Notes de frais",
+    "noExpenses": "Aucune note de frais trouvée.",
+    "view": "Voir",
+    "columns": {
+      "employee": "Employé",
+      "date": "Date",
+      "total": "Total",
+      "status": "Statut"
+    },
+    "status": {
+      "DRAFT": "Brouillon",
+      "SUBMITTED": "Soumis",
+      "APPROVED_MANAGER": "Approuvé par le manager",
+      "APPROVED_ACCOUNTING": "Approuvé par la comptabilité",
+      "REJECTED": "Rejeté",
+      "REIMBURSED": "Remboursé"
     }
   },
   "auditLog": {

--- a/nexus-erp/src/app/[locale]/(app)/expenses/page.tsx
+++ b/nexus-erp/src/app/[locale]/(app)/expenses/page.tsx
@@ -1,0 +1,67 @@
+import { redirect } from 'next/navigation'
+import Box from '@mui/material/Box'
+import Typography from '@mui/material/Typography'
+import { getTranslations } from 'next-intl/server'
+import { db } from '@/db/client'
+import { auth } from '@/auth'
+import { canViewAllExpenses, canViewTeamExpenses } from '@/lib/expenseAccess'
+import ExpensesTable from '@/components/ExpensesTable'
+
+const ExpensesPage = async () => {
+  const session = await auth()
+  if (!session?.user.employeeId) redirect('/dashboard')
+
+  const [viewAll, t] = await Promise.all([
+    canViewAllExpenses(session, db),
+    getTranslations('expenses'),
+  ])
+
+  const viewTeam = canViewTeamExpenses(session)
+
+  let employeeIdFilter: string | { in: string[] } | undefined
+
+  if (viewAll) {
+    employeeIdFilter = undefined
+  } else if (viewTeam) {
+    const reports = await db.employee.findMany({
+      where: { managerId: session.user.employeeId },
+      select: { id: true },
+    })
+    const ids = [session.user.employeeId, ...reports.map((r) => r.id)]
+    employeeIdFilter = { in: ids }
+  } else {
+    employeeIdFilter = session.user.employeeId
+  }
+
+  const expenses = await db.expenseReport.findMany({
+    where: {
+      ...(employeeIdFilter !== undefined ? { employeeId: employeeIdFilter } : {}),
+    },
+    include: {
+      lineItems: { select: { amount: true }, orderBy: { date: 'asc' } },
+      employee: { select: { fullName: true } },
+    },
+    orderBy: { createdAt: 'desc' },
+  })
+
+  const serialized = expenses.map((exp) => ({
+    ...exp,
+    createdAt: exp.createdAt.toISOString(),
+    updatedAt: exp.updatedAt.toISOString(),
+    lineItems: exp.lineItems.map((item) => ({
+      amount: Number(item.amount),
+    })),
+  }))
+
+  const showEmployee = viewAll || viewTeam
+
+  return (
+    <Box>
+      <Box sx={{ mb: 3 }}>
+        <Typography variant="h2">{t('title')}</Typography>
+      </Box>
+      <ExpensesTable expenses={serialized} showEmployee={showEmployee} />
+    </Box>
+  )
+}
+export default ExpensesPage

--- a/nexus-erp/src/components/AppSidebar.tsx
+++ b/nexus-erp/src/components/AppSidebar.tsx
@@ -23,6 +23,7 @@ import InboxRoundedIcon from '@mui/icons-material/InboxRounded'
 import BusinessRoundedIcon from '@mui/icons-material/BusinessRounded'
 import DescriptionRoundedIcon from '@mui/icons-material/DescriptionRounded'
 import ReceiptRoundedIcon from '@mui/icons-material/ReceiptRounded'
+import ReceiptLongRoundedIcon from '@mui/icons-material/ReceiptLongRounded'
 import ShoppingCartRoundedIcon from '@mui/icons-material/ShoppingCartRounded'
 import AccountTreeRoundedIcon from '@mui/icons-material/AccountTreeRounded'
 import PlayCircleRoundedIcon from '@mui/icons-material/PlayCircleRounded'
@@ -84,6 +85,7 @@ const AppSidebar = ({ role, hasEmployee }: AppSidebarProps) => {
       title: t('sections.operations'),
       items: [
         { label: t('items.timesheets'), href: '/timesheets', icon: <AccessTimeRoundedIcon fontSize="small" />, requiresEmployee: true },
+        { label: t('items.expenses'), href: '/expenses', icon: <ReceiptLongRoundedIcon fontSize="small" />, requiresEmployee: true },
         { label: t('items.employees'),  href: '/employees',  icon: <PeopleRoundedIcon fontSize="small" />, managerOnly: true },
         { label: t('items.taskInbox'), href: '/tasks',      icon: <InboxRoundedIcon fontSize="small" /> },
         { label: t('items.messages'),  href: '/messages',   icon: <MailRoundedIcon fontSize="small" /> },

--- a/nexus-erp/src/components/ExpensesTable.tsx
+++ b/nexus-erp/src/components/ExpensesTable.tsx
@@ -1,0 +1,131 @@
+'use client'
+
+import NextLink from 'next/link'
+import Box from '@mui/material/Box'
+import Button from '@mui/material/Button'
+import Card from '@mui/material/Card'
+import Chip from '@mui/material/Chip'
+import Table from '@mui/material/Table'
+import TableBody from '@mui/material/TableBody'
+import TableCell from '@mui/material/TableCell'
+import TableHead from '@mui/material/TableHead'
+import TableRow from '@mui/material/TableRow'
+import Typography from '@mui/material/Typography'
+import { useTranslations } from 'next-intl'
+
+// ── Types ──────────────────────────────────────────────────────────────────────
+
+type ExpenseStatus =
+  | 'DRAFT'
+  | 'SUBMITTED'
+  | 'APPROVED_MANAGER'
+  | 'APPROVED_ACCOUNTING'
+  | 'REJECTED'
+  | 'REIMBURSED'
+
+interface ExpenseRow {
+  id: string
+  status: ExpenseStatus
+  createdAt: string
+  lineItems: { amount: number }[]
+  employee: { fullName: string }
+}
+
+interface ExpensesTableProps {
+  expenses: ExpenseRow[]
+  showEmployee: boolean
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+const STATUS_COLORS: Record<
+  ExpenseStatus,
+  'default' | 'warning' | 'info' | 'success' | 'error'
+> = {
+  DRAFT: 'default',
+  SUBMITTED: 'warning',
+  APPROVED_MANAGER: 'info',
+  APPROVED_ACCOUNTING: 'success',
+  REJECTED: 'error',
+  REIMBURSED: 'success',
+}
+
+// ── Component ──────────────────────────────────────────────────────────────────
+
+const ExpensesTable = ({ expenses, showEmployee }: ExpensesTableProps) => {
+  const t = useTranslations('expenses')
+
+  return (
+    <Card>
+      {expenses.length === 0 ? (
+        <Box sx={{ p: 4, textAlign: 'center' }}>
+          <Typography variant="body2" color="text.secondary">
+            {t('noExpenses')}
+          </Typography>
+        </Box>
+      ) : (
+        <Table>
+          <TableHead>
+            <TableRow>
+              {showEmployee && <TableCell>{t('columns.employee')}</TableCell>}
+              <TableCell>{t('columns.date')}</TableCell>
+              <TableCell>{t('columns.total')}</TableCell>
+              <TableCell>{t('columns.status')}</TableCell>
+              <TableCell align="right" />
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {expenses.map((exp) => {
+              const total = exp.lineItems.reduce(
+                (sum, item) => sum + item.amount,
+                0,
+              )
+              return (
+                <TableRow
+                  key={exp.id}
+                  sx={{ '&:hover': { backgroundColor: 'action.hover' } }}
+                >
+                  {showEmployee && (
+                    <TableCell>
+                      <Typography variant="body2" fontWeight={500}>
+                        {exp.employee.fullName}
+                      </Typography>
+                    </TableCell>
+                  )}
+                  <TableCell>
+                    <Typography variant="body2" color="text.secondary">
+                      {new Date(exp.createdAt).toLocaleDateString()}
+                    </Typography>
+                  </TableCell>
+                  <TableCell>
+                    <Typography variant="body2">
+                      {total.toFixed(2)}
+                    </Typography>
+                  </TableCell>
+                  <TableCell>
+                    <Chip
+                      label={t(`status.${exp.status}`)}
+                      size="small"
+                      color={STATUS_COLORS[exp.status]}
+                    />
+                  </TableCell>
+                  <TableCell align="right">
+                    <Button
+                      component={NextLink}
+                      href={`/expenses/${exp.id}`}
+                      size="small"
+                      variant="text"
+                    >
+                      {t('view')}
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              )
+            })}
+          </TableBody>
+        </Table>
+      )}
+    </Card>
+  )
+}
+export default ExpensesTable


### PR DESCRIPTION
closes #93

## Summary

**Expense list page & navigation**
- Add `/expenses` server page with role-aware data fetching
- Add `ExpensesTable` client component with status badges
- Add expenses entry to AppSidebar Operations section
- Add i18n keys to en/fr/es locales

## Test plan
- [ ] Lint passes (0 errors)
- [ ] Typecheck passes
- [ ] AppSidebar tests pass (8/8)

Generated with [Claude Code](https://claude.ai/code)