### PR TITLE
feat(app): API key authentication

### DIFF
--- a/nexus-workflow-app/src/config.ts
+++ b/nexus-workflow-app/src/config.ts
@@ -3,15 +3,6 @@ const apiKeys = rawApiKeys.split(',').map(k => k.trim()).filter(Boolean)
 
 const nodeEnv = process.env['NODE_ENV'] ?? 'development'
 
-if (apiKeys.length === 0) {
-  if (nodeEnv === 'production') {
-    console.error('[config] API_KEYS is required in production. Set a comma-separated list of keys (e.g. openssl rand -hex 32). Exiting.')
-    process.exit(1)
-  } else {
-    console.warn('[config] API_KEYS is not set — all requests will be rejected with 401. Set API_KEYS to enable access.')
-  }
-}
-
 export const config = {
   port: Number(process.env['PORT'] ?? 3000),
   databaseUrl: process.env['DATABASE_URL'] ?? 'postgres://nexus:nexus@localhost:5433/nexus_workflow',
@@ -23,4 +14,17 @@ export const config = {
   requestTimeoutMs: Number(process.env['REQUEST_TIMEOUT_MS'] ?? 30_000),
   /** Valid API keys read from API_KEYS env var (comma-separated). */
   apiKeys,
+}
+
+/**
+ * Validates the config and exits the process (in production) or warns (in development)
+ * if required values are missing. Call this explicitly in main.ts after importing config.
+ */
+export function assertConfigValid(cfg: typeof config) {
+  if (cfg.apiKeys.length === 0 && cfg.nodeEnv === 'production') {
+    console.error('[config] API_KEYS is required in production. Set a comma-separated list of keys (e.g. openssl rand -hex 32). Exiting.')
+    process.exit(1)
+  } else if (cfg.apiKeys.length === 0) {
+    console.warn('[config] API_KEYS is not set — all requests will be rejected with 401. Set API_KEYS to enable access.')
+  }
 }

--- a/nexus-workflow-app/src/http/middleware/auth.test.ts
+++ b/nexus-workflow-app/src/http/middleware/auth.test.ts
@@ -20,6 +20,7 @@ describe('auth middleware', () => {
       const res = await app.fetch(new Request('http://localhost/protected'))
       expect(res.status).toBe(401)
       expect(await res.json()).toEqual({ error: 'unauthorized' })
+      expect(res.headers.get('WWW-Authenticate')).toBe('Bearer realm="nexus-workflow"')
     })
 
     it('401 when key is wrong', async () => {
@@ -31,6 +32,7 @@ describe('auth middleware', () => {
       )
       expect(res.status).toBe(401)
       expect(await res.json()).toEqual({ error: 'unauthorized' })
+      expect(res.headers.get('WWW-Authenticate')).toBe('Bearer realm="nexus-workflow"')
     })
 
     it('401 when Authorization scheme is not Bearer', async () => {
@@ -42,6 +44,7 @@ describe('auth middleware', () => {
       )
       expect(res.status).toBe(401)
       expect(await res.json()).toEqual({ error: 'unauthorized' })
+      expect(res.headers.get('WWW-Authenticate')).toBe('Bearer realm="nexus-workflow"')
     })
 
     it('200 when key is valid', async () => {
@@ -73,6 +76,7 @@ describe('auth middleware', () => {
         }),
       )
       expect(res.status).toBe(401)
+      expect(res.headers.get('WWW-Authenticate')).toBe('Bearer realm="nexus-workflow"')
     })
   })
 

--- a/nexus-workflow-app/src/http/middleware/auth.ts
+++ b/nexus-workflow-app/src/http/middleware/auth.ts
@@ -1,3 +1,4 @@
+import { timingSafeEqual } from 'node:crypto'
 import type { Context, Next } from 'hono'
 
 /**
@@ -8,6 +9,12 @@ import type { Context, Next } from 'hono'
  *
  * The `/health` path is always bypassed so liveness probes work without credentials.
  */
+
+function safeEq(a: string, b: string): boolean {
+  if (a.length !== b.length) return false
+  return timingSafeEqual(Buffer.from(a), Buffer.from(b))
+}
+
 export function createAuthMiddleware(apiKeys: string[]) {
   return async function authMiddleware(c: Context, next: Next) {
     if (c.req.path === '/health') {
@@ -16,12 +23,16 @@ export function createAuthMiddleware(apiKeys: string[]) {
 
     const authHeader = c.req.header('Authorization')
     if (!authHeader) {
-      return c.json({ error: 'unauthorized' }, 401)
+      return c.json({ error: 'unauthorized' }, 401, {
+        'WWW-Authenticate': 'Bearer realm="nexus-workflow"',
+      })
     }
 
     const [scheme, key] = authHeader.split(' ')
-    if (scheme !== 'Bearer' || !key || !apiKeys.includes(key)) {
-      return c.json({ error: 'unauthorized' }, 401)
+    if (scheme !== 'Bearer' || !key || !apiKeys.some(k => safeEq(k, key))) {
+      return c.json({ error: 'unauthorized' }, 401, {
+        'WWW-Authenticate': 'Bearer realm="nexus-workflow"',
+      })
     }
 
     return next()

--- a/nexus-workflow-app/src/main.ts
+++ b/nexus-workflow-app/src/main.ts
@@ -2,7 +2,7 @@ import { serve } from '@hono/node-server'
 import { Hono } from 'hono'
 import { timeout } from 'hono/timeout'
 import { InMemoryEventBus } from 'nexus-workflow-core'
-import { config } from './config.js'
+import { config, assertConfigValid } from './config.js'
 import { PostgresStateStore } from './db/PostgresStateStore.js'
 import { runMigrations } from './db/migrate.js'
 import { createDefinitionsRouter } from './http/definitions.js'
@@ -19,6 +19,8 @@ import { LogHandler } from './worker/handlers/LogHandler.js'
 import { PostgresScheduler } from './scheduler/PostgresScheduler.js'
 import { TimerCoordinator } from './scheduler/TimerCoordinator.js'
 import { RedisStreamPublisher } from './events/RedisStreamPublisher.js'
+
+assertConfigValid(config)
 
 const store = new PostgresStateStore(config.databaseUrl)
 const eventBus = new InMemoryEventBus()


### PR DESCRIPTION
## Summary

**Config**
- Added `apiKeys: string[]` to `src/config.ts`, parsed from `API_KEYS` env var (comma-separated)
- Warns on startup if empty in development; exits in production

**Middleware**
- New `src/http/middleware/auth.ts`: reads `Authorization: Bearer <key>`, returns `401 { error: "unauthorized" }` on missing or invalid key
- `GET /health` is always bypassed so liveness probes work without credentials

**Wiring**
- `src/main.ts`: `app.use('*', createAuthMiddleware(config.apiKeys))` registered before all API routes

Closes #139

## Test plan
- [x] 8 unit tests pass: missing header, wrong key, non-Bearer scheme, valid key, multiple keys, empty key list, health bypass with/without keys
- [x] Full test suite: 287 non-DB tests pass (5 DB tests skipped — require live PostgreSQL)
- [x] Lint: 0 errors
- [x] Typecheck: passes

## Known limitations
- Existing router unit tests mount routers directly without auth middleware and do not need auth headers — auth is only applied at the full app level

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>